### PR TITLE
Speaker-person matching tests

### DIFF
--- a/pombola/settings/tests_south_africa.py
+++ b/pombola/settings/tests_south_africa.py
@@ -8,6 +8,9 @@ HAYSTACK_CONNECTIONS['default']['EXCLUDED_INDEXES'] = [
     'speeches.search_indexes.SpeechIndex',
 ]
 
+# Set test index name
+HAYSTACK_CONNECTIONS['default']['INDEX_NAME'] = os.environ.get('DATABASE_NAME', 'pombola') + '_test'
+
 INSTALLED_APPS = insert_after(INSTALLED_APPS,
                               'markitup',
                               'pombola.' + COUNTRY_APP)

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -90,12 +90,12 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
                                   family_name='van der Merwe',
                                   given_name='Lilian Luca',
                                   slug='lilian-luca-van-der-merwe'),
-            # # Mr M S F DE FREITAS
-            # Person.objects.create(title='Mr',
-            #                       legal_name='Mario Steven Foster De Freitas',
-            #                       family_name='de freita',
-            #                       given_name='Mario Steven Foster',
-            #                       slug='mario-steven-foster-de-freitas'),
+            # Mr M S F DE FREITAS
+            Person.objects.create(title='Mr',
+                                  legal_name='Mario Steven Foster De Freitas',
+                                  family_name='de freitas',
+                                  given_name='Mario Steven Foster',
+                                  slug='mario-steven-foster-de-freitas'),
         ]
         NUM_PERSONS = len(PERSONS)
 

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -17,7 +17,10 @@ from instances.tests import InstanceTestCase
 from popolo_name_resolver.resolve import EntityName, recreate_entities
 
 from speeches.models import Speaker, Section
-from pombola.za_hansard.importers.import_za_akomantoso import ImportZAAkomaNtoso, title_case_heading
+from pombola.za_hansard.importers.import_za_akomantoso import (
+    ImportZAAkomaNtoso,
+    title_case_heading,
+)
 from pombola.za_hansard.models import Source
 from pombola_sayit.models import PombolaSayItJoin
 from pombola.core.models import Person
@@ -25,27 +28,28 @@ from popolo.models import Person as PopoloPerson
 from popolo_name_resolver.models import EntityName
 
 import logging
+
 logging.disable(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
-@attr(country='south_africa')
+@attr(country="south_africa")
 class ImportZAAkomaNtosoTests(InstanceTestCase):
     @classmethod
     def setUpClass(cls):
         cls._in_fixtures = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)), 'test_inputs',
-            'hansard')
+            os.path.abspath(os.path.dirname(__file__)), "test_inputs", "hansard"
+        )
         super(ImportZAAkomaNtosoTests, cls).setUpClass()
 
         # Delete test index
-        requests.delete('http://elasticsearch:9200/pombola_test')
-        call_command('update_index', interactive=False, verbosity=3)
+        requests.delete("http://elasticsearch:9200/pombola_test")
+        call_command("update_index", interactive=False, verbosity=3)
         recreate_entities()
 
     def test_import_hansard_twice(self):
         Person.objects.all().delete()
-        document_path = os.path.join(self._in_fixtures, 'SMALL_HANSARD.xml')
+        document_path = os.path.join(self._in_fixtures, "SMALL_HANSARD.xml")
 
         speakers_before = Speaker.objects.count()
 
@@ -54,101 +58,120 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
         section1 = an.import_document(document_path)
         section2 = an.import_document(document_path)
         self.assertNotEqual(
-            section1, section2,
-            'The document should be imported as two different sections.')
+            section1,
+            section2,
+            "The document should be imported as two different sections.",
+        )
 
         speaker_name = "Mr M S F Some Unknown Surname"
         speaker_count = Speaker.objects.filter(name=speaker_name).count()
 
         speakers_after = Speaker.objects.count()
         self.assertEqual(
-            1, speaker_count,
-            'Only one speaker should be created for %s, but %d were created' %
-            (speaker_name, speaker_count))
+            1,
+            speaker_count,
+            "Only one speaker should be created for %s, but %d were created"
+            % (speaker_name, speaker_count),
+        )
 
     def test_import_hansard_speakers(self):
-        document_name = 'NA200912.xml'
+        document_name = "NA200912.xml"
         document_path = os.path.join(self._in_fixtures, document_name)
 
         # Create Persons to identify
         PERSONS = [
             # Ms A C MASHISHI: debateBody -> debateSection -> debateSection -> speech
-            Person.objects.create(title='Ms',
-                                  legal_name='Agnes Christin Mashishi',
-                                  family_name='Mashishi',
-                                  given_name='Agnes Christin',
-                                  slug='agnes-christin-mashishi'),
+            Person.objects.create(
+                title="Ms",
+                legal_name="Agnes Christin Mashishi",
+                family_name="Mashishi",
+                given_name="Agnes Christin",
+                slug="agnes-christin-mashishi",
+            ),
             # Dr P J RABIE
-            Person.objects.create(title='Dr',
-                                  legal_name='Petrus Johannes Rabie',
-                                  family_name='Rabie',
-                                  given_name='Petrus Johannes',
-                                  slug='petrus-johannes-rabie'),
+            Person.objects.create(
+                title="Dr",
+                legal_name="Petrus Johannes Rabie",
+                family_name="Rabie",
+                given_name="Petrus Johannes",
+                slug="petrus-johannes-rabie",
+            ),
             # Ms L L VAN DER MERWE
-            Person.objects.create(title='Ms',
-                                  legal_name='Lilian Luca van der Merwe',
-                                  family_name='van der Merwe',
-                                  given_name='Lilian Luca',
-                                  slug='lilian-luca-van-der-merwe'),
+            Person.objects.create(
+                title="Ms",
+                legal_name="Lilian Luca van der Merwe",
+                family_name="van der Merwe",
+                given_name="Lilian Luca",
+                slug="lilian-luca-van-der-merwe",
+            ),
             # Mr M S F DE FREITAS
-            Person.objects.create(title='Mr',
-                                  legal_name='Mario Steven Foster De Freitas',
-                                  family_name='de freitas',
-                                  given_name='Mario Steven Foster',
-                                  slug='mario-steven-foster-de-freitas'),
+            Person.objects.create(
+                title="Mr",
+                legal_name="Mario Steven Foster De Freitas",
+                family_name="de freitas",
+                given_name="Mario Steven Foster",
+                slug="mario-steven-foster-de-freitas",
+            ),
         ]
         NUM_PERSONS = len(PERSONS)
 
         # Create Speakers for the persons
-        call_command('pombola_sayit_sync_pombola_to_popolo', verbosity=3)
-        self.assertEqual(NUM_PERSONS, PombolaSayItJoin.objects.count(),
-                         'Speakers should be linked to persons.')
+        call_command("pombola_sayit_sync_pombola_to_popolo", verbosity=3)
+        self.assertEqual(
+            NUM_PERSONS,
+            PombolaSayItJoin.objects.count(),
+            "Speakers should be linked to persons.",
+        )
         for person in PERSONS:
             person.refresh_from_db()
             self.assertIsNotNone(
                 person.sayit_link.sayit_speaker,
-                'Speaker should be linked to person %s by pombola_sayit_sync_pombola_to_popolo'
-                % (person.legal_name))
+                "Speaker should be linked to person %s by pombola_sayit_sync_pombola_to_popolo"
+                % (person.legal_name),
+            )
 
         SPEAKERS = [person.sayit_link.sayit_speaker for person in PERSONS]
 
         # Create EntityName objects
-        call_command('popolo_name_resolver_init', verbosity=3)
+        call_command("popolo_name_resolver_init", verbosity=3)
         self.assertGreaterEqual(
-            EntityName.objects.count(), NUM_PERSONS,
-            'More than %d EntityNames should be created for speakers, but only %d were created.'
-            % (NUM_PERSONS, EntityName.objects.count()))
+            EntityName.objects.count(),
+            NUM_PERSONS,
+            "More than %d EntityNames should be created for speakers, but only %d were created."
+            % (NUM_PERSONS, EntityName.objects.count()),
+        )
 
         # Create Source
         source = Source.objects.create(
             title="Test hansard",
             document_name=document_name,
             document_number="001",
-            url='api.pmg.org.za/test-hansard',
-            language='English',
+            url="api.pmg.org.za/test-hansard",
+            language="English",
             last_processing_success=date.today(),
-            house='NA',
+            house="NA",
             date=date.today(),
         )
 
         # Run the za_hansard_load_into_sayit command
-        instance = Instance.objects.create(label='default')
-        with patch.object(Source, 'xml_file_path', return_value=document_path):
+        instance = Instance.objects.create(label="default")
+        with patch.object(Source, "xml_file_path", return_value=document_path):
             out = BytesIO()
-            call_command('za_hansard_load_into_sayit', id=source.id, stdout=out)
+            call_command("za_hansard_load_into_sayit", id=source.id, stdout=out)
             output = out.getvalue()
-            self.assertIn('Imported 1 / 1 sections', output)
-            lines = output.split('\n')
+            self.assertIn("Imported 1 / 1 sections", output)
+            lines = output.split("\n")
             # Get the section id of the section that was created
-            for i in range(len(lines)-1, -1, -1):
+            for i in range(len(lines) - 1, -1, -1):
                 if lines[i].strip():
                     section_id = lines[i].strip("[]")
                     break
 
         section = Section.objects.get(id=int(section_id))
 
-        self.assertTrue(section is not None,
-                        'Hansard should be parsed into a non-null section.')
+        self.assertTrue(
+            section is not None, "Hansard should be parsed into a non-null section."
+        )
 
         # Get all the detected speakers from the speeches in the hansard
         detected_speakers = set()
@@ -159,9 +182,10 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
         # Check that the speakers were linked correctly to the above created Persons
         for speaker in SPEAKERS:
             self.assertIn(
-                speaker, detected_speakers,
-                '%s should be detected in the hansard as a speaker' %
-                speaker.name)
+                speaker,
+                detected_speakers,
+                "%s should be detected in the hansard as a speaker" % speaker.name,
+            )
 
     def test_title_casing(self):
         tests = (

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -37,6 +37,9 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             os.path.abspath(os.path.dirname(__file__)), 'test_inputs',
             'hansard')
         super(ImportZAAkomaNtosoTests, cls).setUpClass()
+
+        # Delete test index
+        requests.delete('http://elasticsearch:9200/pombola_test')
         call_command('update_index', interactive=False, verbosity=3)
         recreate_entities()
 
@@ -64,9 +67,6 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             (speaker_name, speaker_count))
 
     def test_import_hansard_speakers(self):
-        # Delete test index
-        requests.delete('http://elasticsearch:9200/pombola_test')
-
         document_name = 'NA200912.xml'
         document_path = os.path.join(self._in_fixtures, document_name)
 
@@ -156,8 +156,6 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             for speech in section.speech_set.all():
                 detected_speakers.add(speech.speaker)
 
-        # print(detected_speakers)
-        # self.assertFalse(True)
         # Check that the speakers were linked correctly to the above created Persons
         for speaker in SPEAKERS:
             self.assertIn(

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -90,12 +90,12 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
                                   family_name='van der Merwe',
                                   given_name='Lilian Luca',
                                   slug='lilian-luca-van-der-merwe'),
-            # Mr M S F DE FREITAS
-            Person.objects.create(title='Mr',
-                                  legal_name='Mario Steven Foster De Freitas',
-                                  family_name='de freita',
-                                  given_name='Mario Steven Foster',
-                                  slug='mario-steven-foster-de-freitas'),
+            # # Mr M S F DE FREITAS
+            # Person.objects.create(title='Mr',
+            #                       legal_name='Mario Steven Foster De Freitas',
+            #                       family_name='de freita',
+            #                       given_name='Mario Steven Foster',
+            #                       slug='mario-steven-foster-de-freitas'),
         ]
         NUM_PERSONS = len(PERSONS)
 

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -131,9 +131,7 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             date=date.today(),
         )
 
-        # an = ImportZAAkomaNtoso(instance=self.instance, commit=True)
-        # section = an.import_document(document_path)
-
+        # Run the za_hansard_load_into_sayit command
         instance = Instance.objects.create(label='default')
         with patch.object(Source, 'xml_file_path', return_value=document_path):
             out = BytesIO()
@@ -146,7 +144,8 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
                 if lines[i].strip():
                     section_id = lines[i].strip("[]")
                     break
-            section = Section.objects.get(id=int(section_id))
+
+        section = Section.objects.get(id=int(section_id))
 
         self.assertTrue(section is not None,
                         'Hansard should be parsed into a non-null section.')
@@ -157,6 +156,8 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             for speech in section.speech_set.all():
                 detected_speakers.add(speech.speaker)
 
+        print(detected_speakers)
+        self.assertFalse(True)
         # Check that the speakers were linked correctly to the above created Persons
         for speaker in SPEAKERS:
             self.assertIn(

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -3,54 +3,136 @@
 import os
 
 from django.core.management import call_command
-from django.utils.unittest import skip
+from nose.plugins.attrib import attr
 
 from instances.tests import InstanceTestCase
 from popolo_name_resolver.resolve import EntityName, recreate_entities
 
 from speeches.models import Speaker
 from pombola.za_hansard.importers.import_za_akomantoso import ImportZAAkomaNtoso, title_case_heading
+from pombola.za_hansard.models import Source
+from pombola_sayit.models import PombolaSayItJoin
+from pombola.core.models import Person
+from popolo.models import Person as PopoloPerson
+from popolo_name_resolver.models import EntityName
 
 import logging
 logging.disable(logging.WARNING)
+logger = logging.getLogger(__name__)
 
 
+@attr(country='south_africa')
 class ImportZAAkomaNtosoTests(InstanceTestCase):
-
     @classmethod
     def setUpClass(cls):
-        cls._in_fixtures = os.path.join(os.path.abspath(
-            os.path.dirname(__file__)), 'test_inputs', 'hansard')
+        cls._in_fixtures = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), 'test_inputs',
+            'hansard')
         super(ImportZAAkomaNtosoTests, cls).setUpClass()
-        call_command('update_index', interactive=False, verbosity=0)
+        call_command('update_index', interactive=False, verbosity=3)
         recreate_entities()
 
-    @skip("Depends on external API data")
-    def test_import(self):
-        return
+    def test_import_hansard_speakers_with_no_persons(self):
+        Person.objects.all().delete()
+        # TODO: import two hansards that contain speakers that are in both of them
+        document_path = os.path.join(self._in_fixtures, 'SMALL_HANSARD.xml')
+
+        speakers_before = Speaker.objects.count()
+
+        # Import the same document twice
+        an = ImportZAAkomaNtoso(instance=self.instance, commit=True)
+        section1 = an.import_document(document_path)
+        section2 = an.import_document(document_path)
+        self.assertNotEqual(
+            section1, section2,
+            'The document should be importec as two different sections.')
+
+        # TODO: double check that the document was actually imported twice
+        speakers_after = Speaker.objects.count()
+        self.assertEqual(
+            speakers_after, speakers_before + 1,
+            'Only one speaker should be created, but %d were created' %
+            (speakers_after - speakers_before))
+
+    def test_import_hansard_speakers(self):
+        self.assertTrue(False, 'Check if this test actually runs in Travis')
         document_path = os.path.join(self._in_fixtures, 'NA200912.xml')
 
+        # Create Persons to identify
+        PERSONS = [
+            # Ms A C MASHISHI: debateBody -> debateSection -> debateSection -> speech
+            Person.objects.create(title='Ms',
+                                  legal_name='Agnes Christin Mashishi',
+                                  family_name='Mashishi',
+                                  given_name='Agnes Christin',
+                                  slug='agnes-christin-mashishi'),
+            # Dr P J RABIE
+            Person.objects.create(title='Dr',
+                                  legal_name='Petrus Johannes Rabie',
+                                  family_name='Rabie',
+                                  given_name='Petrus Johannes',
+                                  slug='petrus-johannes-rabie'),
+            # Ms L L VAN DER MERWE
+            Person.objects.create(title='Ms',
+                                  legal_name='Lilian Luca van der Merwe',
+                                  family_name='van der Merwe',
+                                  given_name='Lilian Luca',
+                                  slug='lilian-luca-van-der-merwe'),
+            # Mr M S F DE FREITAS
+            Person.objects.create(title='Mr',
+                                  legal_name='Mario Steven Foster DE FREITAS',
+                                  family_name='de freita',
+                                  given_name='Mario Steven Foster',
+                                  slug='mario-steven-foster-de-freitas'),
+        ]
+        NUM_PERSONS = len(PERSONS)
+
+        # Create Speakers for the persons
+        call_command('pombola_sayit_sync_pombola_to_popolo', verbosity=3)
+        self.assertEqual(NUM_PERSONS, PombolaSayItJoin.objects.count(),
+                         'Speakers should be linked to persons.')
+        for person in PERSONS:
+            person.refresh_from_db()
+            self.assertIsNotNone(
+                person.sayit_link.sayit_speaker,
+                'Speaker should be linked to person %s by pombola_sayit_sync_pombola_to_popolo'
+                % (person.legal_name))
+
+        SPEAKERS = [person.sayit_link.sayit_speaker for person in PERSONS]
+
+        # Create EntityName objects
+        call_command('popolo_name_resolver_init', verbosity=3)
+        self.assertGreaterEqual(
+            EntityName.objects.count(), NUM_PERSONS,
+            'More than %d EntityNames should be created for speakers, but only %d were created.'
+            % (NUM_PERSONS, EntityName.objects.count()))
+
+        # TODO: create the below XML file as a "Source" instead
         an = ImportZAAkomaNtoso(instance=self.instance, commit=True)
         section = an.import_document(document_path)
 
-        self.assertTrue(section is not None)
+        # source = Source.objects.create()
+        # TODO: mock where XML is gotten?
+        # call_command('za_hansard_load_into_sayit', id=source.id)
 
-        # Check that all the sections have correct looking titles
-        for sub in section.children.all():
-            self.assertFalse("Member'S" in sub.title)
+        self.assertTrue(section is not None,
+                        'Hansard should be parsed into a non-null section.')
 
-        speakers = Speaker.objects.all()
-        resolved = filter(lambda s: s.person != None, speakers)
-        THRESHOLD = 48
+        # Get all the detected speakers from the speeches in the hansard
+        detected_speakers = set()
+        for section in section.children.all():
+            for speech in section.speech_set.all():
+                detected_speakers.add(speech.speaker)
 
-        logging.info(
-            "%d above threshold %d/%d?"
-            % (len(resolved), THRESHOLD, len(speakers)))
+        # TODO: should we check that the correct section is linked to the correct speaker?
+        # TODO: check that the speakers are linked to a Person and redirect will happen correctly?
 
-        self.assertTrue(
-            len(resolved) >= THRESHOLD,
-            "%d above threshold %d/%d"
-            % (len(resolved), THRESHOLD, len(speakers)))
+        # Check that the speakers were linked correctly to the above created Persons
+        for speaker in SPEAKERS:
+            self.assertIn(
+                speaker, detected_speakers,
+                '%s should be detected in the hansard as a speaker' %
+                speaker.name)
 
     def test_title_casing(self):
         tests = (

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -32,9 +32,8 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
         call_command('update_index', interactive=False, verbosity=3)
         recreate_entities()
 
-    def test_import_hansard_speakers_with_no_persons(self):
+    def test_import_hansard_twice(self):
         Person.objects.all().delete()
-        # TODO: import two hansards that contain speakers that are in both of them
         document_path = os.path.join(self._in_fixtures, 'SMALL_HANSARD.xml')
 
         speakers_before = Speaker.objects.count()
@@ -45,14 +44,16 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
         section2 = an.import_document(document_path)
         self.assertNotEqual(
             section1, section2,
-            'The document should be importec as two different sections.')
+            'The document should be imported as two different sections.')
 
-        # TODO: double check that the document was actually imported twice
+        speaker_name = "Mr M S F Some Unknown Surname"
+        speaker_count = Speaker.objects.filter(name=speaker_name).count()
+
         speakers_after = Speaker.objects.count()
         self.assertEqual(
-            speakers_after, speakers_before + 1,
-            'Only one speaker should be created, but %d were created' %
-            (speakers_after - speakers_before))
+            1, speaker_count,
+            'Only one speaker should be created for %s, but %d were created' %
+            (speaker_name, speaker_count))
 
     def test_import_hansard_speakers(self):
         document_path = os.path.join(self._in_fixtures, 'NA200912.xml')

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -55,7 +55,6 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             (speakers_after - speakers_before))
 
     def test_import_hansard_speakers(self):
-        self.assertTrue(False, 'Check if this test actually runs in Travis')
         document_path = os.path.join(self._in_fixtures, 'NA200912.xml')
 
         # Create Persons to identify

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -92,7 +92,7 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
                                   slug='lilian-luca-van-der-merwe'),
             # Mr M S F DE FREITAS
             Person.objects.create(title='Mr',
-                                  legal_name='Mario Steven Foster DE FREITAS',
+                                  legal_name='Mario Steven Foster De Freitas',
                                   family_name='de freita',
                                   given_name='Mario Steven Foster',
                                   slug='mario-steven-foster-de-freitas'),
@@ -156,8 +156,8 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
             for speech in section.speech_set.all():
                 detected_speakers.add(speech.speaker)
 
-        print(detected_speakers)
-        self.assertFalse(True)
+        # print(detected_speakers)
+        # self.assertFalse(True)
         # Check that the speakers were linked correctly to the above created Persons
         for speaker in SPEAKERS:
             self.assertIn(

--- a/pombola/za_hansard/tests/test_akomantoso_import.py
+++ b/pombola/za_hansard/tests/test_akomantoso_import.py
@@ -43,7 +43,7 @@ class ImportZAAkomaNtosoTests(InstanceTestCase):
         super(ImportZAAkomaNtosoTests, cls).setUpClass()
 
         # Delete test index
-        requests.delete("http://elasticsearch:9200/pombola_test")
+        call_command("rebuild_index", interactive=False, verbosity=3)
         call_command("update_index", interactive=False, verbosity=3)
         recreate_entities()
 

--- a/pombola/za_hansard/tests/test_commands.py
+++ b/pombola/za_hansard/tests/test_commands.py
@@ -3,10 +3,13 @@ from datetime import date, time
 from django.test import TestCase
 from django.core.management import call_command
 
+from nose.plugins.attrib import attr
+
 from speeches.tests.helpers import create_sections
 from speeches.models import Speech, Tag
 
 
+@attr(country='south_africa')
 class OneOffTagSpeechesTests(TestCase):
 
     def setUp(self):

--- a/pombola/za_hansard/tests/test_inputs/hansard/SMALL_HANSARD.xml
+++ b/pombola/za_hansard/tests/test_inputs/hansard/SMALL_HANSARD.xml
@@ -1,0 +1,56 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0/CSD03">
+  <debate name="PROCEEDINGS OF THE NATIONAL ASSEMBLY">
+    <meta>
+      <identification source="#mysociety">
+        <FRBRWork>
+          <FRBRthis value="/za/debaterecord/2012-09-20/main"/>
+          <FRBRuri value="/za/debaterecord/2012-09-20"/>
+          <FRBRdate date="3000-01-01" name="generation"/>
+          <FRBRauthor href="#za-parliament"/>
+          <FRBRcountry value="za"/>
+        </FRBRWork>
+        <FRBRExpression>
+          <FRBRthis value="/za/debaterecord/2012-09-20/eng@/main"/>
+          <FRBRuri value="/za/debaterecord/2012-09-20/eng@"/>
+          <FRBRdate date="3000-01-01" name="markup"/>
+          <FRBRauthor href="#za-parliament"/>
+          <FRBRlanguage language="eng"/>
+        </FRBRExpression>
+        <FRBRManifestation>
+          <FRBRthis value="/za/debaterecord/2012-09-20/eng@/main.xml"/>
+          <FRBRuri value="/za/debaterecord/2012-09-20/eng@.akn"/>
+          <FRBRdate date="3000-01-01" name="markup"/>
+          <FRBRauthor href="#mysociety"/>
+        </FRBRManifestation>
+      </identification>
+      <references source="#mysociety">
+        <TLCOrganization href="http://www.parliament.gov.za/" id="za-parliament" showAs="ZA Parliament"/>
+        <TLCOrganization href="http://www.mysociety.org/" id="mysociety" showAs="MySociety"/>
+        <TLCPerson href="http://dummy/popit/path/mr-m-s-f-some-unknown-surname" id="mr-m-s-f-some-unknown-surname" showAs="Mr M S F SOME UNKNOWN SURNAME"/>
+      </references>
+    </meta>
+    <preface>
+      <p>Thursday, <docDate date="2012-09-20">20 September 2012</docDate></p>
+    </preface>
+    <debateBody>
+      <debateSection id="db0" name="proceedings-of-the-national-assembly">
+        <heading id="dbh0">PROCEEDINGS OF THE NATIONAL ASSEMBLY</heading>
+        <p>The House met at <recordedTime time="14:03:00">14:03</recordedTime></p>
+        <prayers id="prayers">
+          <p>The Speaker took the Chair and requested members to observe a moment of silence for prayers or meditation.</p>
+        </prayers>
+        <debateSection id="dbs1" name="announcements-tablings-and-committee-reports">
+          <heading id="dbsh1">ANNOUNCEMENTS, TABLINGS AND COMMITTEE REPORTS </heading>
+        </debateSection>
+        <debateSection id="dbs3" name="notices-of-motion">
+          <heading id="dbsh3">NOTICES OF MOTION</heading>
+          <speech by="#mr-m-s-f-some-unknown-surname">
+            <from>Mr M S F SOME UNKNOWN SURNAME</from>
+            <p>Mr Speaker, I hereby give notice that on the next sitting day of the House I shall move on behalf of the DA:</p>
+            <p>That the House debates the current barriers, problems and solutions to lifting visa requirements in SADC countries where currently no visa waiver exists, and the impact that this has on our economy and the creation of jobs.</p>
+          </speech>
+        </debateSection>
+      </debateSection>
+    </debateBody>
+  </debate>
+</akomaNtoso>


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/170644833)

Adds an integration test that tests the `pombola_sayit_sync_pombola_to_popolo`, `popolo_name_resolver_init` and `za_hansard_load_into_sayit` commands.