### PR TITLE
Optimise the hansard view

### DIFF
--- a/pombola/south_africa/fallback_urls.py
+++ b/pombola/south_africa/fallback_urls.py
@@ -24,7 +24,7 @@ from pombola.south_africa.views import (
 urlpatterns = [
     url(r'^committee/(?P<pk>\d+)$', OldSectionRedirect.as_view()),
     url(r'^question/(?P<pk>\d+)$', OldSectionRedirect.as_view()),
-    url(r'^hansard/(?P<pk>\d+)$', OldSectionRedirect.as_view()),
+    url(r'^hansard/(?P<pk>\d+)$', OldSectionRedirect.as_view(), name='hansard-view'),
 
     url(r'^committee/speech/(?P<pk>\d+)$', OldSpeechRedirect.as_view()),
     url(r'^question/speech/(?P<pk>\d+)$', OldSpeechRedirect.as_view()),

--- a/pombola/south_africa/fallback_urls.py
+++ b/pombola/south_africa/fallback_urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, include, url
 
 from pombola.south_africa.views import (
-    OldSectionRedirect, OldSpeechRedirect,
+    SectionRedirect, OldSpeechRedirect,
     SASpeechView, SASectionView,
     SAHansardIndex, SACommitteeIndex, SAQuestionIndex,
     SASpeakerRedirectView)
@@ -22,9 +22,9 @@ from pombola.south_africa.views import (
 #  /hansard/928
 
 urlpatterns = [
-    url(r'^committee/(?P<pk>\d+)$', OldSectionRedirect.as_view()),
-    url(r'^question/(?P<pk>\d+)$', OldSectionRedirect.as_view()),
-    url(r'^hansard/(?P<pk>\d+)$', OldSectionRedirect.as_view(), name='hansard-view'),
+    url(r'^committee/(?P<pk>\d+)$', SectionRedirect.as_view()),
+    url(r'^question/(?P<pk>\d+)$', SectionRedirect.as_view()),
+    url(r'^hansard/(?P<pk>\d+)$', SectionRedirect.as_view(), name='hansard-view'),
 
     url(r'^committee/speech/(?P<pk>\d+)$', OldSpeechRedirect.as_view()),
     url(r'^question/speech/(?P<pk>\d+)$', OldSpeechRedirect.as_view()),

--- a/pombola/south_africa/templates/south_africa/hansard_index.html
+++ b/pombola/south_africa/templates/south_africa/hansard_index.html
@@ -48,7 +48,7 @@
         <div class="js-hide-reveal hansard-section" id="{{ t.grouper|slugify }}-{{ first_section_id }}">
             {% for item in t.list %}
             <p>
-                <a href="{% url 'speeches:section-view' item.path %}">{{ item.title }}</a>
+                <a href="{% url 'hansard-view' item.id %}">{{ item.title }}</a>
                 ({{ item.speech_count }})
             </p>
             {% endfor %}

--- a/pombola/south_africa/templates/south_africa/hansard_index.html
+++ b/pombola/south_africa/templates/south_africa/hansard_index.html
@@ -48,7 +48,7 @@
         <div class="js-hide-reveal hansard-section" id="{{ t.grouper|slugify }}-{{ first_section_id }}">
             {% for item in t.list %}
             <p>
-                <a href="{% url 'speeches:section-view' item.get_path %}">{{ item.title }}</a>
+                <a href="{% url 'speeches:section-view' item.path %}">{{ item.title }}</a>
                 ({{ item.speech_count }})
             </p>
             {% endfor %}

--- a/pombola/south_africa/templates/south_africa/hansard_index.html
+++ b/pombola/south_africa/templates/south_africa/hansard_index.html
@@ -6,7 +6,7 @@
   {% javascript 'hide-reveal' %}
 {% endblock %}
 
-{% block title %}Hansard{% endblock %}
+{% block title %}{{ top_section_name }}{% endblock %}
 
 
 {% block content %}

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1580,7 +1580,8 @@ class SAHansardIndexViewTest(TestCase):
         response = client.get('/hansard/%s' % section.id)
         self.assertRedirects(
             response,
-            reverse('speeches:section-view', args=[section.get_path])
+            reverse('speeches:section-view', args=[section.get_path]),
+            fetch_redirect_response=False
         )
 
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -43,6 +43,8 @@ from pombola.core.views import PersonSpeakerMappingsMixin
 from instances.models import Instance
 from pombola.interests_register.models import Category, Release, Entry, EntryLineItem
 
+from pombola.za_hansard.models import Source
+
 from nose.plugins.attrib import attr
 from pygeolib import GeocoderError
 
@@ -1544,6 +1546,19 @@ class SAHansardIndexViewTest(TestCase):
                 ],
             },
         ])
+        section_name = "Proceedings of the National Assembly (2012/2/16)"
+        section = Section.objects.get(heading=section_name)
+        source = Source.objects.create(
+            title='Test source',
+            document_name='NA: Unrevised hansard',
+            document_number='1234',
+            date=date(2013, 2, 18),
+            url='https://api.pmg.org.za/committee-meeting/29935/',
+            house='NA',
+            language='English',
+            is404=False,
+            sayit_section=section
+        )
 
     def test_index_page(self):
         c = Client()
@@ -1555,7 +1570,7 @@ class SAHansardIndexViewTest(TestCase):
 
         # Check that we can see the headings of sections containing speeches only
         self.assertContains(response, section_name)
-        self.assertContains(response, '<a href="/%s">%s</a>' % (section.get_path, section_name), html=True)
+        self.assertContains(response, '<a href="/hansard/%s">%s</a>' % (section.id, section_name), html=True)
         self.assertNotContains(response, "Empty section")
 
 @attr(country='south_africa')
@@ -1621,8 +1636,7 @@ class SACommitteeIndexViewTest(WebTest):
         self.assertContains(response, "16 November 2012")
         self.assertContains(response, self.fish_section_heading)
         self.assertContains(response,
-                            '<a href="/%s">%s</a>' % (section.get_path,
-                                                      self.fish_section_heading),
+                            '<a href="/hansard/%s">%s</a>' % (section.id, self.fish_section_heading),
                             html=True)
         self.assertNotContains(response, "Empty section")
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1573,6 +1573,17 @@ class SAHansardIndexViewTest(TestCase):
         self.assertContains(response, '<a href="/hansard/%s">%s</a>' % (section.id, section_name), html=True)
         self.assertNotContains(response, "Empty section")
 
+    def test_hansard_redirect(self):
+        client = Client()
+        section_name = "Proceedings of Foo"
+        section = Section.objects.get(heading=section_name)
+        response = client.get('/hansard/%s' % section.id)
+        self.assertRedirects(
+            response,
+            reverse('speeches:section-view', args=[section.get_path])
+        )
+
+
 @attr(country='south_africa')
 class SACommitteeIndexViewTest(WebTest):
 

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -14,6 +14,7 @@ from haystack.inputs import AutoQuery
 
 from pombola.core import models
 from pombola.core.views import PersonSpeakerMappingsMixin
+from pombola.za_hansard.models import Source
 
 from slug_helpers.views import SlugRedirect
 
@@ -64,8 +65,9 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
 
         # exclude sections without subsections and
         # with subsections that have no speeches
+        section_ids = Source.objects.values('sayit_section_id')
         section_filter = {
-            self.section_parent_field: top_section,
+            'id__in': section_ids,
             'children__speech__id__isnull': False,
             'children__id__isnull': False
         }

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -63,12 +63,14 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
         # FIXME ideally we'd have start_date for sections rather than
         # having to get MAX('start_date') from the speeches table
 
-        # exclude sections without subsections and
-        # with subsections that have no speeches
+        # Use the ZAHansard Source objects to find all of the hansards' 
+        # top-level sections
         section_ids = Source.objects.values('sayit_section_id')
         section_filter = {
             'id__in': section_ids,
+            # exclude sections without subsections
             'children__speech__id__isnull': False,
+            # and with subsections that have no speeches
             'children__id__isnull': False
         }
 

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -106,6 +106,7 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
         
         context['entries'] = debate_sections
         context['page_obj'] = parent_section_headings
+        context['top_section_name'] = self.top_section_name
         return context
 
 

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -335,10 +335,8 @@ class OldSpeechRedirect(RedirectView):
             raise Http404
 
 
-class OldSectionRedirect(RedirectView):
-    """Redirects from an old section URL to the current one"""
-
-    permanent = True
+class SectionRedirect(RedirectView):
+    """Redirects from an section URL with an ID to one with the full slug."""
 
     def get_redirect_url(self, *args, **kwargs):
         try:

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -92,14 +92,9 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
         except EmptyPage:
             parent_section_headings = paginator.page(paginator.num_pages)
 
-        # get the sections for the current page in date order
-        headings = list(section['id'] for section in parent_section_headings)
-        section_filter['id__in'] = headings
-        parent_sections = parent_section_headings.object_list
-
         # get the subsections based on the relevant section ids
         # exclude those with blank headings as we have no way of linking to them
-        parent_ids = list(section['id'] for section in parent_sections)
+        parent_ids = list(section['id'] for section in parent_section_headings)
         debate_sections = Section \
             .objects \
             .filter(parent_id__in=parent_ids, speech__id__isnull=False) \

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -104,10 +104,19 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
         debate_sections = Section \
             .objects \
             .filter(parent_id__in=parent_ids, speech__id__isnull=False) \
-            .annotate(start_order=Min('speech__id'), speech_start_date=Max('speech__start_date'), speech_count=Count('speech__id')) \
+            .annotate(
+                start_order=Min('speech__id'), 
+                speech_start_date=Max('speech__start_date'), 
+                speech_count=Count('speech__id')) \
             .exclude(heading='') \
+            .select_related(
+                'parent__heading', 'parent__num', 'parent__subheading', 'parent__slug',
+                'parent__parent__slug',
+                'parent__parent__parent__slug',
+                'parent__parent__parent__parent__slug',
+                ) \
             .order_by('-speech_start_date', 'parent__heading', 'start_order')
-
+        
         context['entries'] = debate_sections
         context['page_obj'] = parent_section_headings
         return context

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -43,6 +43,7 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
     sections_to_show = 25
 
     def get_section_filter(self):
+        # Get the hansard sections using the ZAHansard Source model.
         section_ids = Source.objects.values('sayit_section_id')
         return {
             'id__in': section_ids,
@@ -73,7 +74,6 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
         # Use the ZAHansard Source objects to find all of the hansards' 
         # top-level sections
 
-        # get a list of all the section headings
         section_filter = self.get_section_filter()
 
         # Select distinct parent sections headings 
@@ -96,9 +96,9 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
         except EmptyPage:
             parent_section_headings = paginator.page(paginator.num_pages)
         
+        # get the sections for the current page in date order
         headings = list(section['heading'] for section in parent_section_headings)
         section_filter['heading__in'] = headings
-        # Get all of the sections for the headings
         parent_sections = Section \
             .objects \
             .values('id', 'heading') \

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -42,7 +42,7 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
     top_section_name = 'Hansard'
     sections_to_show = 25
 
-    def get_section_filter():
+    def get_section_filter(self):
         section_ids = Source.objects.values('sayit_section_id')
         return {
             'id__in': section_ids,
@@ -126,7 +126,7 @@ class SACommitteeIndex(SASpeechesIndex):
     top_section_name = 'Committee Minutes'
     sections_to_show = 25
 
-    def get_section_filter():
+    def get_section_filter(self):
         top_section = get_object_or_404(
             Section, heading=self.top_section_name, parent=None)
         return {

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -107,19 +107,22 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
                 speech_count=Count('speech__id')) \
             .exclude(heading='') \
             .select_related(
-                'parent__heading', 'parent__num', 'parent__subheading', 'parent__slug',
+                'parent__slug',
                 'parent__parent__slug',
                 'parent__parent__parent__slug',
                 'parent__parent__parent__parent__slug',
+                'parent__parent__parent__parent__parent__slug',
                 ) \
             .order_by('-speech_start_date', 'parent__heading', 'start_order')
         
         for debate_section in debate_sections:
             debate_section.path = '/'.join([
-                debate_section.slug,
-                debate_section.parent.slug,
-                debate_section.parent.parent.slug,
+                'hansard',
+                debate_section.parent.parent.parent.parent.slug,
                 debate_section.parent.parent.parent.slug,
+                debate_section.parent.parent.slug,
+                debate_section.parent.slug,
+                debate_section.slug,
             ])
 
         

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -337,6 +337,7 @@ class OldSpeechRedirect(RedirectView):
 
 class SectionRedirect(RedirectView):
     """Redirects from an section URL with an ID to one with the full slug."""
+    permanent = False
 
     def get_redirect_url(self, *args, **kwargs):
         try:

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -107,24 +107,9 @@ class SASpeechesIndex(NamespaceMixin, TemplateView):
                 speech_count=Count('speech__id')) \
             .exclude(heading='') \
             .select_related(
-                'parent__slug',
-                'parent__parent__slug',
-                'parent__parent__parent__slug',
-                'parent__parent__parent__parent__slug',
-                'parent__parent__parent__parent__parent__slug',
+                'parent__slug', 'parent__heading'
                 ) \
             .order_by('-speech_start_date', 'parent__heading', 'start_order')
-        
-        for debate_section in debate_sections:
-            debate_section.path = '/'.join([
-                'hansard',
-                debate_section.parent.parent.parent.parent.slug,
-                debate_section.parent.parent.parent.slug,
-                debate_section.parent.parent.slug,
-                debate_section.parent.slug,
-                debate_section.slug,
-            ])
-
         
         context['entries'] = debate_sections
         context['page_obj'] = parent_section_headings


### PR DESCRIPTION
Reduces the time to load for the hansard page (/hansard) from around 18 000ms to around 1 000ms and the number of queries from 2102 to 8.

The execution time of the committee meetings page (/committee-meetings) stayed more or less the same at 2 000ms, but the number of queries were reduced from 448 queries to 8 queries.

The largest query was the one where tried to get the children's children's children's (etc.) of the top-level "Hansard" section:

![2020-04-15-09:10](https://user-images.githubusercontent.com/4767109/79311440-b82cf080-7efd-11ea-86f4-b93408450117.png)

Now we're rather getting the hansard sections using the 'sayit_section_id` of the ZAHansard Source model:

![2020-04-15-09:12](https://user-images.githubusercontent.com/4767109/79311494-cda21a80-7efd-11ea-9836-b1d67e289518.png)

The high number of queries were caused by the `get_path` function where we build up a URL using the section's parents's slugs. I've replaced the calls to `get_path` to use the section's ID instead since we already had a URL pattern that accepts a section's ID.

