### PR TITLE
Show all MPs and MPLs in the RepLocator if they're linked to the office/area

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -579,7 +579,7 @@ class Person(ModelBase, HasImageMixin, ScorecardMixin, IdentifierMixin):
 
         This is specific to the South African site (ZA).
         """
-        contacts = self.position_set.filter(title__slug="constituency-contact").currently_active()
+        contacts = self.position_set.filter(organisation__kind__slug__in=['constituency-area', 'constituency-office']).currently_active()
         return Organisation.objects.filter(position__in=contacts)
 
     def aspirant_constituencies(self):

--- a/pombola/south_africa/templates/south_africa/_position_listing_constituency.html
+++ b/pombola/south_africa/templates/south_africa/_position_listing_constituency.html
@@ -14,7 +14,9 @@
         <span class="name">{{ position.person.name }}</span>
     </a>
 
-    <div class="position-title">{{ position.title }}</div>
+    {% if position.title %}
+      <div class="position-title">{{ position.title }}</div>
+    {% endif %}
 
     {% if position.person.parties %}
       <div class="position-parties">

--- a/pombola/south_africa/views/geolocalization.py
+++ b/pombola/south_africa/views/geolocalization.py
@@ -191,9 +191,7 @@ class LatLonDetailBaseView(BasePlaceDetailView):
                         has_party_logo = True
 
             # Find all the constituency contacts:
-            for i, position in enumerate(organisation.position_set.filter(
-                title__slug='constituency-contact'
-            ).currently_active()):
+            for i, position in enumerate(organisation.position_set.currently_active()):
                 person = position.person
                 element_id = 'constituency-contact-{office_id}-{i}'.format(
                     office_id=position.organisation.id, i=i

--- a/pombola/south_africa/views/geolocalization.py
+++ b/pombola/south_africa/views/geolocalization.py
@@ -15,7 +15,7 @@ from haystack.forms import SearchForm
 
 from pombola.core import models
 from pombola.core.views import (
-    BasePlaceDetailView, PlaceDetailView, PlaceDetailSub)
+    BasePlaceDetailView, BaseDetailView, PlaceDetailView, PlaceDetailSub)
 from pombola.search.views import GeocoderView
 
 from pombola.south_africa.models import ZAPlace
@@ -54,7 +54,8 @@ class LocationSearchForm(SearchForm):
         widget=forms.TextInput(attrs={'placeholder': 'Your address'}))
 
 
-class LatLonDetailBaseView(BasePlaceDetailView):
+class LatLonDetailBaseView(BaseDetailView):
+    model = models.Place
     # Using 25km as the default, as that's what's used on MyReps.
     constituency_office_search_radius = 25
 


### PR DESCRIPTION
In the past, we only showed MPs and MPLs with the "constituency contact" position at an office, in the RepLocator. PMG wants all of the MPs and MPLs to be shown.

This PR also fixes the issue where the constituency office wasn't shown on a person's profile page if they were linked to the office, but did not have the "constituency contact" role.

[Pivotal](https://www.pivotaltracker.com/story/show/172145867)

![Screenshot of what multiple results look like](https://user-images.githubusercontent.com/4767109/78676296-8527a300-78e6-11ea-872c-cfe5bbe16526.png)


