### PR TITLE
Fix house exception in hansard scraper

### DIFF
--- a/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -207,7 +207,7 @@ class Command(BaseCommand):
             'National Assembly': 'N'
         }.get(data['house']['name'])
         if not house:
-            print "Skipping {} because the house {} is not supported".format(
+            print "Skipping {} because the house {} is not supported.".format(
                 data['url'], data['house']['name'])
             return
         if data['answer_type'] not in ANSWER_TYPES:

--- a/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -205,7 +205,11 @@ class Command(BaseCommand):
             return
         house = {
             'National Assembly': 'N'
-        }[data['house']['name']]
+        }.get(data['house']['name'])
+        if not house:
+            print "Skipping {} because the house {} is not supported".format(
+                data['url'], data['house']['name'])
+            return
         if data['answer_type'] not in ANSWER_TYPES:
             print "Skipping {} because the answer type {} is not supported".format(
                 data['url'], data['answer_type'])

--- a/pombola/za_hansard/tests/test_pmg_q_and_a.py
+++ b/pombola/za_hansard/tests/test_pmg_q_and_a.py
@@ -428,3 +428,28 @@ class PMGAPITests(TestCase):
         self.assertTrue(QuestionParsingError.objects.filter(error_type='number-not-found').exists())
 
         fake_sys_exit.assert_called_with(1)
+
+    @patch('pombola.za_hansard.management.commands.za_hansard_q_and_a_scraper.all_from_api')
+    def test_unsupported_house(self, fake_all_from_api):
+        question_with_invalid_house = copy.deepcopy(EXAMPLE_QUESTION)
+        question_with_invalid_house['house']['name'] = u'National Council of Provinces'
+        def api_one_question_and_answer(url):
+            if url == 'https://api.pmg.org.za/minister/':
+                yield {
+                    'questions_url': "http://api.pmg.org.za/minister/2/questions/",
+                }
+                return
+            elif url == 'https://api.pmg.org.za/member/':
+                return
+            elif url == 'http://api.pmg.org.za/minister/2/questions/':
+                yield question_with_invalid_house
+            else:
+                raise Exception("Unfaked URL '{0}'".format(url))
+        fake_all_from_api.side_effect = api_one_question_and_answer
+
+        # Run the command:
+        call_command('za_hansard_q_and_a_scraper', scrape_from_pmg=True)
+
+        # Check that no new questions or answers were created
+        self.assertEqual(Question.objects.count(), 0)
+        self.assertEqual(Answer.objects.count(), 0)


### PR DESCRIPTION
Fix the exception that was raised by the hansard scraper:

```
Traceback (most recent call last):
  File "./manage.py", line 45, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 354, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 346, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 394, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 445, in execute
    output = self.handle(*args, **options)
  File "/app/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py", line 185, in handle
    self.get_qa_from_pmg_api(*args, **options)
  File "/app/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py", line 424, in get_qa_from_pmg_api
    self.handle_api_question_and_reply(question)
  File "/app/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py", line 208, in handle_api_question_and_reply
    }[data['house']['name']]
KeyError: u'National Council of Provinces'
```

[Pivotal](https://www.pivotaltracker.com/story/show/172473102)