### PR TITLE
[WIP] Allow NCOP questions to be imported

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -2138,7 +2138,26 @@ li, div {
     .speech-title {
         font-weight: bold;
         font-size: 1.142857143em;
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+
+        .speech-url {
+          margin-bottom: 3px;
+        }
+
+        .speech-house {
+          color: $colour_primary_light;
+          border: solid 1px $colour_primary_light;
+          padding: 0.1em;
+          font-weight: normal;
+          font-size: 0.8em;
+          border-radius: 0.5em;
+          padding: 0.5px 5px;
+          flex-shrink: 1;
+        }
     }
+
 
     li {
         margin-bottom: 0.5em;

--- a/pombola/south_africa/templates/core/person_speech_list.html
+++ b/pombola/south_africa/templates/core/person_speech_list.html
@@ -22,13 +22,18 @@
     <li>
         <p>
             <span class="speech-title">
-                <a href="{% url 'speeches:section-view' speech.section.get_path %}#s{{ speech.id }}">
+                <a class="speech-url" href="{% url 'speeches:section-view' speech.section.get_path %}#s{{ speech.id }}">
                     {% if parent_title %}
                         {{ speech.section.parent.title }}
                     {% else %}
                         {{ speech.section.title }}
                     {% endif %}
                 </a>
+                {% if speech.section.question.house_name %}
+                  <span class="speech-house">
+                    {{ speech.section.question.house_name }}
+                  </span>
+                {% endif %}
             </span>
             <span class="speech-date">
                 {{ speech.start_date }}

--- a/pombola/south_africa/templates/core/person_speech_list.html
+++ b/pombola/south_africa/templates/core/person_speech_list.html
@@ -29,11 +29,13 @@
                         {{ speech.section.title }}
                     {% endif %}
                 </a>
-                {% if speech.section.question.house_name %}
-                  <span class="speech-house">
-                    {{ speech.section.question.house_name }}
-                  </span>
-                {% endif %}
+                {% with house_name=speech.section.question.house_name %}
+                  {% if house_name %}
+                    <span class="speech-house">
+                      {{ house_name }}
+                    </span>
+                  {% endif %}
+                {% endwith %}
             </span>
             <span class="speech-date">
                 {{ speech.start_date }}

--- a/pombola/south_africa/templates/south_africa/person_appearances.html
+++ b/pombola/south_africa/templates/south_africa/person_appearances.html
@@ -7,12 +7,14 @@
 
 {% block subcontent %}
 
-  <h2>Appearances</h2>
+  <section class="person-appearances">
+    <h2>Appearances</h2>
 
-  {% autopaginate speeches %}
+    {% autopaginate speeches %}
 
-  {% include "core/person_speech_list.html" with speechlist=speeches %}
+    {% include "core/person_speech_list.html" with speechlist=speeches %}
 
-  {% paginate %}
+    {% paginate %}
+  </section>
 
 {% endblock %}

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -459,6 +459,13 @@ def connection_error(x, *args, **kwargs):
 
 
 @attr(country='south_africa')
+class SAQuestionIndexTest(TestCase):
+    def test_question_view_redirects(self):
+        response = self.client.get(reverse('section-list-question'), follow=False)
+        self.assertRedirects(response, 'https://pmg.org.za/question_replies/', fetch_redirect_response=False)
+
+
+@attr(country='south_africa')
 class SAPersonDetailViewTest(PersonSpeakerMappingsMixin, TestCase):
     def setUp(self):
         # Create the top level SayIt sections, so that there's no

--- a/pombola/south_africa/views/speechviews.py
+++ b/pombola/south_africa/views/speechviews.py
@@ -197,6 +197,9 @@ def questions_section_sort_key(section):
 class SAQuestionIndex(TemplateView):
     template_name = 'south_africa/question_index.html'
 
+    def dispatch(request, *args, **kwargs):
+      return redirect("https://pmg.org.za/question_replies/")
+
     def get_context_data(self, **kwargs):
         context = super(SAQuestionIndex, self).get_context_data(**kwargs)
 

--- a/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -209,7 +209,8 @@ class Command(BaseCommand):
                     data['url'])
             return
         house = {
-            'National Assembly': 'N'
+            'National Assembly': 'N',
+            'National Council of Provinces': 'C'
         }.get(data['house']['name'])
         if not house:
             print "Skipping {} because the house {} is not supported.".format(

--- a/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -208,11 +208,9 @@ class Command(BaseCommand):
                 print "Skipping {0} due to a missing source_file".format(
                     data['url'])
             return
-        house = {
-            'National Assembly': 'N',
-            'National Council of Provinces': 'C'
-        }.get(data['house']['name'])
-        if not house:
+        try:
+            house = Question.get_house_choice(data['house']['name'])
+        except KeyError:
             print "Skipping {} because the house {} is not supported.".format(
                 data['url'], data['house']['name'])
             return

--- a/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
+++ b/pombola/za_hansard/management/commands/za_hansard_q_and_a_scraper.py
@@ -214,13 +214,13 @@ class Command(BaseCommand):
         parsed = {}
 
         if 'source_file' not in data:
-            return False, "Skipping {0} due to a missing source_file".format(data['url'])
+            return False, "Skipping {0} due to a missing source_file".format(data.get('url'))
 
         try:
             parsed['house'] = Question.get_house_choice(data['house']['name'])
         except KeyError:
             return False, "Skipping {} because the house {} is not supported.".format(
-                data['url'], data['house']['name'])
+                data.get('url'), data['house']['name'])
 
         if data['answer_type'] not in ANSWER_TYPES:
             return False, "Skipping {} because the answer type {} is not supported".format(

--- a/pombola/za_hansard/migrations/0014_auto_20200618_0731.py
+++ b/pombola/za_hansard/migrations/0014_auto_20200618_0731.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('za_hansard', '0013_auto_20200327_1633'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='question',
+            name='sayit_section',
+            field=models.OneToOneField(null=True, on_delete=django.db.models.deletion.PROTECT, blank=True, to='speeches.Section', help_text=b'Associated Sayit section object, if imported'),
+        ),
+    ]

--- a/pombola/za_hansard/migrations/0015_auto_20200618_1034.py
+++ b/pombola/za_hansard/migrations/0015_auto_20200618_1034.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('za_hansard', '0014_auto_20200618_0731'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='answer',
+            name='sayit_section',
+            field=models.OneToOneField(null=True, on_delete=django.db.models.deletion.PROTECT, blank=True, to='speeches.Section', help_text=b'Associated Sayit section object, if imported'),
+        ),
+    ]

--- a/pombola/za_hansard/models.py
+++ b/pombola/za_hansard/models.py
@@ -471,6 +471,16 @@ class Question(models.Model):
             raise KeyError
         return choice
 
+    @property
+    def house_name(self):
+        choice = next((choice[1] for choice in house_choices if choice[0] == self.house), None)
+        if not choice:
+            return ''
+        return choice
+
+        if not self.house:
+            return ''
+
 
 # CREATE TABLE completed_documents (`url` string);
 

--- a/pombola/za_hansard/models.py
+++ b/pombola/za_hansard/models.py
@@ -275,7 +275,7 @@ class Answer (models.Model):
     type = models.TextField()
 
     last_sayit_import = models.DateTimeField(blank=True, null=True)
-    sayit_section = models.ForeignKey(
+    sayit_section = models.OneToOneField(
         Section, blank=True, null=True, on_delete=models.PROTECT,
         help_text='Associated Sayit section object, if imported',
     )

--- a/pombola/za_hansard/models.py
+++ b/pombola/za_hansard/models.py
@@ -440,7 +440,7 @@ class Question(models.Model):
     askedby = models.TextField()
 
     last_sayit_import = models.DateTimeField(blank=True, null=True)
-    sayit_section = models.ForeignKey(
+    sayit_section = models.OneToOneField(
         Section, blank=True, null=True, on_delete=models.PROTECT,
         help_text='Associated Sayit section object, if imported',
     )

--- a/pombola/za_hansard/models.py
+++ b/pombola/za_hansard/models.py
@@ -464,6 +464,14 @@ class Question(models.Model):
             ('dp_number', 'house', 'year', 'term'),
         )
 
+    @classmethod
+    def get_house_choice(cls, house_name):
+        choice = next((choice[0] for choice in house_choices if choice[1] == house_name), None)
+        if not choice:
+            raise KeyError
+        return choice
+
+
 # CREATE TABLE completed_documents (`url` string);
 
 

--- a/pombola/za_hansard/tests/test_pmg_q_and_a.py
+++ b/pombola/za_hansard/tests/test_pmg_q_and_a.py
@@ -417,7 +417,7 @@ class PMGAPITests(TestCase):
         fake_all_from_api.side_effect = api_one_question_and_answer
 
         # Run the command:
-        call_command('za_hansard_q_and_a_scraper', scrape_from_pmg=True)
+        call_command('za_hansard_q_and_a_scraper', scrape_from_pmg=True, verbosity=4)
 
         # Check that no new questions or answers were created
         self.assertEqual(Question.objects.count(), 0)
@@ -525,7 +525,6 @@ class ParsePmgQuestionDataTests(TestCase):
             "year": "2016",
             "president_number": None,
             "question_text": "Why did the chicken cross the road?",
-            "question": None,
             "answer_type": "W",
             "deputy_president_number": None,
             "intro": "Groucho Marx to ask the Minister of Arts and Culture",
@@ -553,4 +552,10 @@ class ParsePmgQuestionDataTests(TestCase):
         question = copy.deepcopy(EXAMPLE_QUESTION)
         question['house']['name'] = 'unsupported'
         with self.assertRaisesRegexp(QuestionParsingException, 'unsupported'):
+            result = self.command.parse_pmg_question_data(question)
+
+    def test_unsupported_answer_type(self):
+        question = copy.deepcopy(EXAMPLE_QUESTION)
+        question['answer_type'] = 'unsupported'
+        with self.assertRaisesRegexp(QuestionParsingException, 'answer type'):
             result = self.command.parse_pmg_question_data(question)

--- a/pombola/za_hansard/tests/test_pmg_q_and_a.py
+++ b/pombola/za_hansard/tests/test_pmg_q_and_a.py
@@ -431,75 +431,6 @@ class PMGAPITests(TestCase):
 
         fake_sys_exit.assert_called_with(1)
 
-    @patch('pombola.za_hansard.management.commands.za_hansard_q_and_a_scraper.all_from_api')
-    @patch('pombola.za_hansard.management.commands.za_hansard_q_and_a_scraper.sys.exit')
-    def test_unsupported_house(self, fake_sys_exit, fake_all_from_api):
-        question_with_invalid_house = copy.deepcopy(EXAMPLE_QUESTION)
-        question_with_invalid_house['house']['name'] = u'Unsupported House'
-        def api_one_question_and_answer(url):
-            if url == 'https://api.pmg.org.za/minister/':
-                yield {
-                    'questions_url': "http://api.pmg.org.za/minister/2/questions/",
-                }
-                return
-            elif url == 'https://api.pmg.org.za/member/':
-                return
-            elif url == 'http://api.pmg.org.za/minister/2/questions/':
-                yield question_with_invalid_house
-            else:
-                raise Exception("Unfaked URL '{0}'".format(url))
-        fake_all_from_api.side_effect = api_one_question_and_answer
-
-        # Run the command:
-        out = StringIO()
-        call_command('za_hansard_q_and_a_scraper', scrape_from_pmg=True, verbosity=4, stderr=out)
-
-        # Check that no new questions or answers were created
-        expected_output = "Skipping http://api.pmg.org.za/example-question/5678/ because the house Unsupported House is not supported."
-        self.assertIn(expected_output, out.getvalue())
-        self.assertEqual(Question.objects.count(), 0)
-        self.assertEqual(Answer.objects.count(), 0)
-
-    @patch('pombola.za_hansard.management.commands.za_hansard_q_and_a_scraper.all_from_api')
-    def test_import_ncop_question(self, fake_all_from_api):
-        question_with_invalid_house = copy.deepcopy(EXAMPLE_QUESTION)
-        question_with_invalid_house['house']['name'] = u'National Council of Provinces'
-        def api_one_question_and_answer(url):
-            if url == 'https://api.pmg.org.za/minister/':
-                yield {
-                    'questions_url': "http://api.pmg.org.za/minister/2/questions/",
-                }
-                return
-            elif url == 'https://api.pmg.org.za/member/':
-                return
-            elif url == 'http://api.pmg.org.za/minister/2/questions/':
-                yield question_with_invalid_house
-            else:
-                raise Exception("Unfaked URL '{0}'".format(url))
-        fake_all_from_api.side_effect = api_one_question_and_answer
-
-        # Run the command:
-        call_command('za_hansard_q_and_a_scraper', scrape_from_pmg=True)
-
-        # Check that what we expect has been created:
-        self.assertEqual(Answer.objects.count(), 1)
-        self.assertEqual(Question.objects.count(), 1)
-        answer = Answer.objects.get()
-        question = Question.objects.get()
-
-        # Assertions about the question first:
-        self.assertEqual(
-            question.question, 'Why did the chicken cross the road?')
-        self.assertEqual(question.answer, answer)
-        self.assertEqual(question.written_number, 12345)
-
-        NCOP_LETTER = 'C'
-        self.assertEqual(question.house, NCOP_LETTER)
-        self.assertEqual(question.answer_type, 'W')
-
-        self.assertEqual(answer.text, 'To get to the other side')
-        self.assertEqual(answer.house, NCOP_LETTER)
-        self.assertEqual(answer.processed_code, Answer.PROCESSED_OK)
 
 @attr(country='south_africa')
 class ParsePmgQuestionDataTests(TestCase):
@@ -554,8 +485,27 @@ class ParsePmgQuestionDataTests(TestCase):
         with self.assertRaisesRegexp(QuestionParsingException, 'unsupported'):
             result = self.command.parse_pmg_question_data(question)
 
+    def test_ncop_house(self):
+        question = copy.deepcopy(EXAMPLE_QUESTION)
+        question['house']['name'] = u'National Council of Provinces'
+        result = self.command.parse_pmg_question_data(question)
+        self.assertIs(dict, type(result))
+        self.assertEqual(result['existing_kwargs']['house'], 'C')
+
     def test_unsupported_answer_type(self):
         question = copy.deepcopy(EXAMPLE_QUESTION)
         question['answer_type'] = 'unsupported'
         with self.assertRaisesRegexp(QuestionParsingException, 'answer type'):
+            result = self.command.parse_pmg_question_data(question)
+
+    def test_invalid_term_date(self):
+        question = copy.deepcopy(EXAMPLE_QUESTION)
+        question['date'] = '1990-02-20'
+        with self.assertRaisesRegexp(QuestionParsingException, 'Could not determine the parliamentary term'):
+            result = self.command.parse_pmg_question_data(question)
+
+    def test_invalid_date(self):
+        question = copy.deepcopy(EXAMPLE_QUESTION)
+        question['date'] = 'not-a-date'
+        with self.assertRaisesRegexp(QuestionParsingException, 'Could not parse the date'):
             result = self.command.parse_pmg_question_data(question)


### PR DESCRIPTION
**Remember to run migrations after deploy!**

I imported a few NCOP questions with the scraper and it worked fine. NCOP and NA questions seem to have the same structure. 

[Pivotal](https://www.pivotaltracker.com/story/show/172472649)

pa.org.za/question will redirect to pmg.org.za/question_replies/

Questions on profile page on desktop:

![2020-06-18-08:08](https://user-images.githubusercontent.com/4767109/84984366-f2ec1880-b13a-11ea-8db0-ff8b759a00a7.png)

Questions on profile page on mobile:

![2020-06-18-08:06](https://user-images.githubusercontent.com/4767109/84984410-0ac39c80-b13b-11ea-98c9-81f7bc474e6f.png)

