### PR TITLE
Fix image URL in csv download

### DIFF
--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -593,6 +593,7 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
 
                 return return_date
 
+            image = person.primary_image()
             writer.writerow([
                 person.slug,
                 request.build_absolute_uri(person.get_absolute_url())
@@ -600,8 +601,8 @@ def position(request, pt_slug, ok_slug=None, o_slug=None):
                 person.name,
                 person.honorific_prefix,
                 email,
-                request.build_absolute_uri('/' + str(person.primary_image()))
-                            .replace('http://', 'https://'),
+                request.build_absolute_uri(image.url)
+                            .replace('http://', 'https://') if image else '',
                 person_wikidata_id,
                 person_party_name,
                 person_party_wikidata_id,


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/173767126)

Fix the `UnicodeDecodeError 'ascii' codec can't decode byte 0xc3 in position 9: ordinal not in range(128)` error that happens on https://www.pa.org.za/position/member/parliament/national-assembly/?format=csv.

Page seems to be crawled by Wikimedia and looks like it was built for this purpose.

Change involved using `primary_image().url` instead of `Str(primary_image())` because the former does URL encoding. For example:

```
>>> str(p.primary_image())
'images/D\xc3\x89SIR\xc3\x89E_VAN_DER_WALT.jpg'
>>> p.primary_image().url
'/media_root/images/D%C3%89SIR%C3%89E_VAN_DER_WALT.jpg'
```