### PR TITLE
Rather use 'persons' list from the WriteInPublic messages response

### DIFF
--- a/pombola/writeinpublic/client.py
+++ b/pombola/writeinpublic/client.py
@@ -22,7 +22,7 @@ class Message(RecipientMixin, object):
         return self.adapter.filter(ids=self._recipient_ids())
 
     def _recipient_ids(self):
-        return [self.parse_id(p['resource_uri']) for p in self._params['people']]
+        return [self.parse_id(p) for p in self._params['persons']]
 
     def answers(self):
         return [Answer(a, person=self.adapter.get(self.parse_id(a['person']['resource_uri']))) for a in self._params['answers']]

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -113,10 +113,8 @@ class ClientTest(TestCase):
             'subject': 'Test message',
             'content': 'Test content',
             'created': '2017-11-14T04:01:05.799658',
-            'people': [
-                {
-                    'resource_uri': 'http://example.com/popolo.json#person-123',
-                }
+            'persons': [
+                'http://example.com/popolo.json#person-123',
             ],
             'answers': [
                 {


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/172954678)

[WriteInPublic PR](https://github.com/OpenUpSA/writeinpublic/pull/12)

We're already returning a list called `persons` that contain the resource URIs for all of the people a message was sent to. Rather use this list instead of the `people` list because we want to remove the `people` list from the messages API response.