### PR TITLE
Enable writing to more committees

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -806,6 +806,9 @@ class OrganisationQuerySet(models.query.GeoQuerySet):
             Q(ended='') | Q(ended='future') | 
             Q(ended__isnull=True) | Q(ended__gte=now_approx)
         ))
+    
+    def has_email_contacts(self):
+        return self.filter(contacts__kind__slug='email')
 
     def parties(self):
         return self.filter(kind__slug='party')
@@ -868,6 +871,29 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
 
     class Meta:
        ordering = ["name"]
+
+    @property
+    def has_email_address(self):
+        """
+        Check if we have a contact with kind "email" for this organisation.
+
+        Filter using Python instead of Django because we assume that contacts
+        and their kinds have been prefetched (e.g. prefetch_related(contacts__kind)).
+        """
+        return len([
+            contact for contact in self.contacts.all() if contact.kind.slug=='email'
+        ]) > 0
+    
+    @property
+    def is_committee(self):
+        return self.kind.slug in COMMITTEE_SLUGS
+
+    @property
+    def contactable(self):
+        """
+        Return whether users should be able to write a message to this organisation.
+        """
+        return self.is_committee and self.is_ongoing() and self.has_email_address
 
     def is_ongoing(self):
         """Return True or False for whether the organisation is currently ongoing"""

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -810,7 +810,7 @@ class OrganisationQuerySet(models.query.GeoQuerySet):
     def has_email_contacts(self):
         return self.filter(contacts__kind__slug='email')
 
-    def contactable(self):
+    def contactable_committees(self):
         """
         Return all committees that we want users to be able to write to.
         """
@@ -905,7 +905,7 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
         return self.kind.slug in COMMITTEE_SLUGS
 
     @property
-    def contactable(self):
+    def contactable_committee(self):
         """
         Return whether users should be able to write a message to this organisation.
         """

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -784,7 +784,26 @@ class OrganisationKind(ModelBase):
         return ('organisation_kind', (self.slug,))
 
 
+COMMITTEE_SLUGS = [
+    'ad-hoc-committees',
+    'joint-committees',
+    'national-assembly-committees',
+    'ncop-committees',
+    'provincial-legislature'
+]
+
 class OrganisationQuerySet(models.query.GeoQuerySet):
+    def committees(self):
+        return self.filter(kind__slug__in=COMMITTEE_SLUGS)
+
+    def ongoing(self):
+        now = datetime.date.today()
+        now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
+        return self.filter(Q(started__lte=now_approx) & (
+            Q(ended='') | Q(ended='future') | 
+            Q(ended__isnull=True) | Q(ended__gte=now_approx
+        )))
+
     def parties(self):
         return self.filter(kind__slug='party')
 

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -810,6 +810,12 @@ class OrganisationQuerySet(models.query.GeoQuerySet):
     def has_email_contacts(self):
         return self.filter(contacts__kind__slug='email')
 
+    def contactable(self):
+        """
+        Return all committees that we want users to be able to write to.
+        """
+        return self.committees().ongoing().has_email_contacts()
+
     def parties(self):
         return self.filter(kind__slug='party')
 

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -873,6 +873,18 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
        ordering = ["name"]
 
     @property
+    def email_addresses(self):
+        """
+        Get the contacts with kind "email" for this organisation.
+
+        Filter using Python instead of Django because we assume that contacts
+        and their kinds have been prefetched (e.g. prefetch_related(contacts__kind)).
+        """
+        return [
+            contact for contact in self.contacts.all() if contact.kind.slug=='email'
+        ]
+
+    @property
     def has_email_address(self):
         """
         Check if we have a contact with kind "email" for this organisation.
@@ -880,9 +892,7 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
         Filter using Python instead of Django because we assume that contacts
         and their kinds have been prefetched (e.g. prefetch_related(contacts__kind)).
         """
-        return len([
-            contact for contact in self.contacts.all() if contact.kind.slug=='email'
-        ]) > 0
+        return len(self.email_addresses) > 0
     
     @property
     def is_committee(self):

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -789,7 +789,6 @@ COMMITTEE_SLUGS = [
     'joint-committees',
     'national-assembly-committees',
     'ncop-committees',
-    'provincial-legislature'
 ]
 
 class OrganisationQuerySet(models.query.GeoQuerySet):

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -797,12 +797,16 @@ class OrganisationQuerySet(models.query.GeoQuerySet):
         return self.filter(kind__slug__in=COMMITTEE_SLUGS)
 
     def ongoing(self):
+        """
+        Filter committees with start dates before the current date and end dates
+        either null, '', 'future' or after the current date.
+        """
         now = datetime.date.today()
         now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
         return self.filter(Q(started__lte=now_approx) & (
             Q(ended='') | Q(ended='future') | 
-            Q(ended__isnull=True) | Q(ended__gte=now_approx
-        )))
+            Q(ended__isnull=True) | Q(ended__gte=now_approx)
+        ))
 
     def parties(self):
         return self.filter(kind__slug='party')

--- a/pombola/core/templates/core/organisation_list.html
+++ b/pombola/core/templates/core/organisation_list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load pagination_tags %}
 
-{% block title %}{% if kind %}{{ kind.name }}{% endif %}{% endblock %}
+{% block title %}{% if kind %}{{ kind.name }}{% else %}Organisations{% endif %}{% endblock %}
 
 {% block content %}
 

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -5,19 +5,15 @@ from pombola.core import models
 
 from django.contrib.contenttypes.models import ContentType
 
+
 @attr(country="south_africa")
 class OrganisationTest(TestCase):
     def setUp(self):
-        self.organisation_kind = models.OrganisationKind(
-            name = 'Foo',
-            slug = 'foo',
-        )
+        self.organisation_kind = models.OrganisationKind(name="Foo", slug="foo",)
         self.organisation_kind.save()
 
         self.organisation = models.Organisation(
-            name = 'Test Org',
-            slug = 'test-org',
-            kind = self.organisation_kind,
+            name="Test Org", slug="test-org", kind=self.organisation_kind,
         )
         self.organisation.save()
 
@@ -25,12 +21,12 @@ class OrganisationTest(TestCase):
             identifier="/organisations/1",
             scheme="org.mysociety.za",
             object_id=self.organisation.id,
-            content_type=ContentType.objects.get_for_model(models.Organisation))
+            content_type=ContentType.objects.get_for_model(models.Organisation),
+        )
 
     def testIdentifier(self):
-        org_mysociety_id = self.organisation.get_identifier('org.mysociety.za')
-        self.assertEqual(org_mysociety_id, '/organisations/1')
-
+        org_mysociety_id = self.organisation.get_identifier("org.mysociety.za")
+        self.assertEqual(org_mysociety_id, "/organisations/1")
 
     def tearDown(self):
         self.mysociety_id.delete()

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -184,10 +184,17 @@ class OrganisationModelTest(TestCase):
         self.assertFalse(self.ncop_organisation.contactable_committee)
         self.assertFalse(self.test_organisation.contactable_committee)
 
-    def test_to_str(self):
-        self.assertEqual(
-            "Basic Education (National Assembly)", str(self.na_organisation)
+
+@attr(country="south_africa")
+class OrganisationToStrTest(TestCase):
+    def setUp(self):
+        self.test_kind = OrganisationKind(name="Test Kind", slug="test-kind")
+        self.test_organisation = Organisation(
+            name="Test Org", slug="test-org", kind=self.test_kind, ended="future"
         )
+
+    def test_to_str(self):
+        self.assertEqual("Test Org (Test Kind)", str(self.test_organisation))
 
 
 @attr(country="south_africa")

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -142,17 +142,42 @@ class OrganisationIdentifiersTest(TestCase):
 
 
 @attr(country="south_africa")
+class OrganisationIsCommitteeTest(unittest.TestCase):
+    def setUp(self):
+        self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
+        self.na_kind = OrganisationKind(
+            name="National Assembly", slug="national-assembly-committees",
+        )
+        self.ncop_kind = OrganisationKind(name="NCOP", slug="ncop-committees")
+        self.non_committee_org = Organisation(
+            name="Non-committee",
+            slug="non-committee",
+            kind=self.test_kind,
+            ended="future",
+        )
+        self.na_committee = Organisation(
+            name="NA Committee", slug="na-committee", kind=self.na_kind, ended="future"
+        )
+        self.ncop_committee = Organisation(
+            name="NCOP Committee",
+            slug="ncop-committee",
+            kind=self.ncop_kind,
+            ended="future",
+        )
+
+    def test_is_committee(self):
+        self.assertFalse(self.non_committee_org.is_committee)
+        self.assertTrue(self.na_committee.is_committee)
+        self.assertTrue(self.ncop_committee.is_committee)
+
+
+@attr(country="south_africa")
 class OrganisationModelTest(TestCase):
     def setUp(self):
         create_organisation_kinds(self)
         create_organisations(self)
         create_contact_kinds(self)
         create_contacts(self)
-
-    def test_is_committee(self):
-        self.assertTrue(self.na_organisation.is_committee)
-        self.assertTrue(self.ncop_organisation.is_committee)
-        self.assertFalse(self.test_organisation.is_committee)
 
     def test_contactable_committee(self):
         self.assertTrue(self.na_organisation.contactable_committee)

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -1,5 +1,6 @@
 from nose.plugins.attrib import attr
 from django.test import TestCase
+from django.utils import unittest
 
 from pombola.core.models import (
     Organisation,
@@ -61,6 +62,34 @@ def create_contacts(self):
 
 
 @attr(country="south_africa")
+class OrganisationEmailAddressesModelUnitTest(unittest.TestCase):
+# class OrganisationEmailAddressesModelUnitTest(TestCase):
+    def setUp(self):
+        self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
+        # self.test_kind.save()
+        self.organisation_without_emails = Organisation(
+            name="Test Org", slug="test-org", kind=self.test_kind
+        )
+        # self.organisation_without_emails.save()
+        self.organisation_with_emails = Organisation(
+            name="Basic Education", slug="basic-education", kind=self.test_kind,
+        )
+        # self.organisation_with_emails.save()
+        self.email_kind = ContactKind(name="Email", slug="email")
+        # self.email_kind.save()
+        self.email_contact = Contact(
+            kind=self.email_kind,
+            value="test@example.com",
+            content_object = self.organisation_with_emails,
+            preferred=True,
+        )
+        # self.email_contact.save()
+
+    def test_email_addresses(self):
+        self.assertEqual(0, len(self.organisation_without_emails.email_addresses))
+        self.assertEqual(1, len(self.organisation_with_emails.email_addresses))
+
+@attr(country="south_africa")
 class OrganisationModelTest(TestCase):
     def setUp(self):
         create_organisation_kinds(self)
@@ -77,6 +106,8 @@ class OrganisationModelTest(TestCase):
         )
 
     def test_identifier(self):
+        # Can't be unittest because it looks for identifiers with
+        # Identifier.objects.filter(
         self.create_identifiers()
         org_mysociety_id = self.test_organisation.get_identifier("org.mysociety.za")
         self.assertEqual(org_mysociety_id, "/organisations/1")

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -34,25 +34,34 @@ class OrganisationQuerySetTest(TestCase):
     def setUp(self):
         self.foo_kind = OrganisationKind.objects.create(name="Foo", slug="foo",)
         self.na_kind = OrganisationKind.objects.create(
-            name="National Assembly", slug="national-assembly-committees"
+            name="National Assembly", slug="national-assembly-committees",
         )
         self.ncop_kind = OrganisationKind.objects.create(
             name="NCOP", slug="ncop-committees"
         )
 
         self.test_organisation = Organisation.objects.create(
-            name="Test Org", slug="test-org", kind=self.foo_kind,
+            name="Test Org", slug="test-org", kind=self.foo_kind, ended="future"
         )
 
         self.na_organisation = Organisation.objects.create(
             name="Basic Education", slug="basic-education", kind=self.na_kind,
         )
         self.ncop_organisation = Organisation.objects.create(
-            name="NCOP Appropriations", slug="ncop-appropriations", kind=self.ncop_kind,
+            name="NCOP Appropriations",
+            slug="ncop-appropriations",
+            kind=self.ncop_kind,
+            ended="2010-01-01",
         )
 
-    def testGetCommittees(self):
+    def test_committees(self):
         result = Organisation.objects.committees().all()
         self.assertIn(self.na_organisation, result)
         self.assertIn(self.ncop_organisation, result)
         self.assertNotIn(self.test_organisation, result)
+
+    def test_ongoing(self):
+        result = Organisation.objects.ongoing().all()
+        self.assertIn(self.na_organisation, result)
+        self.assertIn(self.test_organisation, result)
+        self.assertNotIn(self.ncop_organisation, result)

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -122,27 +122,35 @@ class OrganisationOngoingUnitTest(unittest.TestCase):
 
 
 @attr(country="south_africa")
+class OrganisationIdentifiersTest(TestCase):
+# class OrganisationIdentifiersTest(unittest.TestCase):
+    def setUp(self):
+        self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
+        self.test_kind.save()
+        self.test_organisation = Organisation(
+            name="Test Org", slug="test-org", kind=self.test_kind, ended="future"
+        )
+        self.test_organisation.save()
+        self.mysociety_id = Identifier(
+            identifier="/organisations/1",
+            scheme="org.mysociety.za",
+            content_object=self.test_organisation
+        )
+        self.mysociety_id.save()
+
+    def test_identifier(self):
+        # Can't be unittest because it looks for identifiers with
+        # Identifier.objects.filter(
+        org_mysociety_id = self.test_organisation.get_identifier("org.mysociety.za")
+        self.assertEqual(org_mysociety_id, "/organisations/1")
+
+@attr(country="south_africa")
 class OrganisationModelTest(TestCase):
     def setUp(self):
         create_organisation_kinds(self)
         create_organisations(self)
         create_contact_kinds(self)
         create_contacts(self)
-
-    def create_identifiers(self):
-        self.mysociety_id = Identifier.objects.create(
-            identifier="/organisations/1",
-            scheme="org.mysociety.za",
-            object_id=self.test_organisation.id,
-            content_type=ContentType.objects.get_for_model(Organisation),
-        )
-
-    def test_identifier(self):
-        # Can't be unittest because it looks for identifiers with
-        # Identifier.objects.filter(
-        self.create_identifiers()
-        org_mysociety_id = self.test_organisation.get_identifier("org.mysociety.za")
-        self.assertEqual(org_mysociety_id, "/organisations/1")
 
     def test_is_committee(self):
         self.assertTrue(self.na_organisation.is_committee)

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -12,55 +12,62 @@ from pombola.core.models import (
 from django.contrib.contenttypes.models import ContentType
 
 
+def create_organisation_kinds(self):
+    self.foo_kind = OrganisationKind.objects.create(name="Foo", slug="foo",)
+    self.na_kind = OrganisationKind.objects.create(
+        name="National Assembly", slug="national-assembly-committees",
+    )
+    self.ncop_kind = OrganisationKind.objects.create(
+        name="NCOP", slug="ncop-committees"
+    )
+
+def create_organisations(self):
+    self.test_organisation = Organisation.objects.create(
+        name="Test Org", slug="test-org", kind=self.foo_kind, ended="future"
+    )
+
+    self.na_organisation = Organisation.objects.create(
+        name="Basic Education", slug="basic-education", kind=self.na_kind,
+    )
+    self.ncop_organisation = Organisation.objects.create(
+        name="NCOP Appropriations",
+        slug="ncop-appropriations",
+        kind=self.ncop_kind,
+        ended="2010-01-01",
+    )
+
+def create_contact_kinds(self):
+    self.email_kind = ContactKind.objects.create(name="Email", slug="email")
+    self.phone_kind = ContactKind.objects.create(name="Phone", slug="phone")
+
+def create_contacts(self):
+    email_contact = Contact.objects.create(
+        kind=self.email_kind,
+        value="test@example.com",
+        content_type=ContentType.objects.get_for_model(self.na_organisation),
+        object_id=self.na_organisation.id,
+        preferred=True,
+    )
+
+
 @attr(country="south_africa")
 class OrganisationModelTest(TestCase):
     def setUp(self):
         self.organisation_kind = OrganisationKind(name="Foo", slug="foo",)
         self.organisation_kind.save()
-
         self.organisation = Organisation(
+            name="Test Org", slug="test-org", kind=self.organisation_kind,
+        )
+        self.na_organisation = Organisation(
             name="Test Org", slug="test-org", kind=self.organisation_kind,
         )
         self.organisation.save()
 
-        self.mysociety_id = Identifier.objects.create(
-            identifier="/organisations/1",
-            scheme="org.mysociety.za",
-            object_id=self.organisation.id,
-            content_type=ContentType.objects.get_for_model(Organisation),
-        )
-
-    def testIdentifier(self):
-        org_mysociety_id = self.organisation.get_identifier("org.mysociety.za")
-        self.assertEqual(org_mysociety_id, "/organisations/1")
-
-
-@attr(country="south_africa")
-class OrganisationQuerySetTest(TestCase):
-    def create_contact_kinds(self):
-        self.email_kind = ContactKind.objects.create(name="Email", slug="email")
-        self.phone_kind = ContactKind.objects.create(name="Phone", slug="phone")
-
-    def create_contacts(self):
-        email_contact = Contact.objects.create(
-            kind=self.email_kind,
-            value="test@example.com",
-            content_type=ContentType.objects.get_for_model(self.na_organisation),
-            object_id=self.na_organisation.id,
-            preferred=True,
-        )
-
-    def setUp(self):
-        self.foo_kind = OrganisationKind.objects.create(name="Foo", slug="foo",)
         self.na_kind = OrganisationKind.objects.create(
             name="National Assembly", slug="national-assembly-committees",
         )
         self.ncop_kind = OrganisationKind.objects.create(
             name="NCOP", slug="ncop-committees"
-        )
-
-        self.test_organisation = Organisation.objects.create(
-            name="Test Org", slug="test-org", kind=self.foo_kind, ended="future"
         )
 
         self.na_organisation = Organisation.objects.create(
@@ -72,8 +79,57 @@ class OrganisationQuerySetTest(TestCase):
             kind=self.ncop_kind,
             ended="2010-01-01",
         )
+    
+    def create_contact_kinds(self):
+        self.email_kind = ContactKind.objects.create(name="Email", slug="email")
+        self.phone_kind = ContactKind.objects.create(name="Phone", slug="phone")
+
+    def create_contacts(self):
+        self.email_contact = Contact.objects.create(
+            kind=self.email_kind,
+            value="test@example.com",
+            content_type=ContentType.objects.get_for_model(self.organisation),
+            object_id=self.organisation.id,
+            preferred=True,
+        )
+        self.phone_contact = Contact.objects.create(
+            kind=self.phone_kind,
+            value="0000000",
+            content_type=ContentType.objects.get_for_model(self.organisation),
+            object_id=self.organisation.id,
+            preferred=True,
+        )
+
+    def create_identifiers(self):
+        self.mysociety_id = Identifier.objects.create(
+            identifier="/organisations/1",
+            scheme="org.mysociety.za",
+            object_id=self.organisation.id,
+            content_type=ContentType.objects.get_for_model(Organisation),
+        )
+
+    def test_identifier(self):
+        self.create_identifiers()
+        org_mysociety_id = self.organisation.get_identifier("org.mysociety.za")
+        self.assertEqual(org_mysociety_id, "/organisations/1")
+    
+    def test_email_addresses(self):
         self.create_contact_kinds()
         self.create_contacts()
+        contacts = self.organisation.email_addresses
+        self.assertEqual(1, len(contacts))
+        self.assertEqual([self.email_contact], contacts)
+        self.assertTrue(self.organisation.has_email_address)
+        self.assertFalse(self.na_organisation.has_email_address)
+
+
+@attr(country="south_africa")
+class OrganisationQuerySetTest(TestCase):
+    def setUp(self):
+        create_organisation_kinds(self)
+        create_organisations(self)
+        create_contact_kinds(self)
+        create_contacts(self)
 
     def test_committees(self):
         result = Organisation.objects.committees().all()

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -65,6 +65,8 @@ class OrganisationModelTest(TestCase):
     def setUp(self):
         create_organisation_kinds(self)
         create_organisations(self)
+        create_contact_kinds(self)
+        create_contacts(self)
 
     def create_identifiers(self):
         self.mysociety_id = Identifier.objects.create(
@@ -80,14 +82,27 @@ class OrganisationModelTest(TestCase):
         self.assertEqual(org_mysociety_id, "/organisations/1")
 
     def test_email_addresses(self):
-        create_contact_kinds(self)
-        create_contacts(self)
         self.assertEqual(0, len(self.test_organisation.email_addresses))
         na_contacts = self.na_organisation.email_addresses
         self.assertEqual(1, len(na_contacts))
         self.assertEqual([self.email_contact], na_contacts)
         self.assertTrue(self.na_organisation.has_email_address)
         self.assertFalse(self.test_organisation.has_email_address)
+
+    def test_is_committee(self):
+        self.assertTrue(self.na_organisation.is_committee)
+        self.assertTrue(self.ncop_organisation.is_committee)
+        self.assertFalse(self.test_organisation.is_committee)
+
+    def test_contactable(self):
+        self.assertTrue(self.na_organisation.contactable)
+        self.assertFalse(self.ncop_organisation.contactable)
+        self.assertFalse(self.test_organisation.contactable)
+
+    def test_is_ongoing(self):
+        self.assertTrue(self.na_organisation.is_ongoing())
+        self.assertFalse(self.ncop_organisation.is_ongoing())
+        self.assertTrue(self.test_organisation.is_ongoing())
 
 
 @attr(country="south_africa")

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -123,26 +123,23 @@ class OrganisationOngoingUnitTest(unittest.TestCase):
 
 @attr(country="south_africa")
 class OrganisationIdentifiersTest(TestCase):
-# class OrganisationIdentifiersTest(unittest.TestCase):
     def setUp(self):
-        self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
-        self.test_kind.save()
-        self.test_organisation = Organisation(
+        self.test_kind = OrganisationKind.objects.create(
+            name="TestKind", slug="test-kind"
+        )
+        self.test_organisation = Organisation.objects.create(
             name="Test Org", slug="test-org", kind=self.test_kind, ended="future"
         )
-        self.test_organisation.save()
-        self.mysociety_id = Identifier(
+        self.mysociety_id = Identifier.objects.create(
             identifier="/organisations/1",
             scheme="org.mysociety.za",
-            content_object=self.test_organisation
+            content_object=self.test_organisation,
         )
-        self.mysociety_id.save()
 
-    def test_identifier(self):
-        # Can't be unittest because it looks for identifiers with
-        # Identifier.objects.filter(
+    def test_get_identifier(self):
         org_mysociety_id = self.test_organisation.get_identifier("org.mysociety.za")
         self.assertEqual(org_mysociety_id, "/organisations/1")
+
 
 @attr(country="south_africa")
 class OrganisationModelTest(TestCase):

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -104,6 +104,11 @@ class OrganisationModelTest(TestCase):
         self.assertFalse(self.ncop_organisation.is_ongoing())
         self.assertTrue(self.test_organisation.is_ongoing())
 
+    def test_to_str(self):
+        self.assertEqual(
+            "Basic Education (National Assembly)", str(self.na_organisation)
+        )
+
 
 @attr(country="south_africa")
 class OrganisationQuerySetTest(TestCase):

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -1,27 +1,27 @@
 from nose.plugins.attrib import attr
 from django.test import TestCase
 
-from pombola.core import models
+from pombola.core.models import Organisation, OrganisationKind, Identifier
 
 from django.contrib.contenttypes.models import ContentType
 
 
 @attr(country="south_africa")
-class OrganisationTest(TestCase):
+class OrganisationModelTest(TestCase):
     def setUp(self):
-        self.organisation_kind = models.OrganisationKind(name="Foo", slug="foo",)
+        self.organisation_kind = OrganisationKind(name="Foo", slug="foo",)
         self.organisation_kind.save()
 
-        self.organisation = models.Organisation(
+        self.organisation = Organisation(
             name="Test Org", slug="test-org", kind=self.organisation_kind,
         )
         self.organisation.save()
 
-        self.mysociety_id = models.Identifier.objects.create(
+        self.mysociety_id = Identifier.objects.create(
             identifier="/organisations/1",
             scheme="org.mysociety.za",
             object_id=self.organisation.id,
-            content_type=ContentType.objects.get_for_model(models.Organisation),
+            content_type=ContentType.objects.get_for_model(Organisation),
         )
 
     def testIdentifier(self):
@@ -32,3 +32,32 @@ class OrganisationTest(TestCase):
         self.mysociety_id.delete()
         self.organisation.delete()
         self.organisation_kind.delete()
+
+
+@attr(country="south_africa")
+class OrganisationQuerySetTest(TestCase):
+    def setUp(self):
+        self.foo_kind = OrganisationKind.objects.create(name="Foo", slug="foo",)
+        self.na_kind = OrganisationKind.objects.create(
+            name="National Assembly", slug="national-assembly-committees"
+        )
+        self.ncop_kind = OrganisationKind.objects.create(
+            name="NCOP", slug="ncop-committees"
+        )
+
+        self.test_organisation = Organisation.objects.create(
+            name="Test Org", slug="test-org", kind=self.foo_kind,
+        )
+
+        self.na_organisation = Organisation.objects.create(
+            name="Basic Education", slug="basic-education", kind=self.na_kind,
+        )
+        self.ncop_organisation = Organisation.objects.create(
+            name="NCOP Appropriations", slug="ncop-appropriations", kind=self.ncop_kind,
+        )
+
+    def testGetCommittees(self):
+        result = Organisation.objects.committees().all()
+        self.assertIn(self.na_organisation, result)
+        self.assertIn(self.ncop_organisation, result)
+        self.assertNotIn(self.test_organisation, result)

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -62,28 +62,28 @@ def create_contacts(self):
 
 
 @attr(country="south_africa")
-class OrganisationEmailAddressesModelUnitTest(unittest.TestCase):
-# class OrganisationEmailAddressesModelUnitTest(TestCase):
+# class OrganisationEmailAddressesModelUnitTest(unittest.TestCase):
+class OrganisationEmailAddressesModelUnitTest(TestCase):
     def setUp(self):
         self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
-        # self.test_kind.save()
+        self.test_kind.save()
         self.organisation_without_emails = Organisation(
             name="Test Org", slug="test-org", kind=self.test_kind
         )
-        # self.organisation_without_emails.save()
+        self.organisation_without_emails.save()
         self.organisation_with_emails = Organisation(
             name="Basic Education", slug="basic-education", kind=self.test_kind,
         )
-        # self.organisation_with_emails.save()
+        self.organisation_with_emails.save()
         self.email_kind = ContactKind(name="Email", slug="email")
-        # self.email_kind.save()
+        self.email_kind.save()
         self.email_contact = Contact(
             kind=self.email_kind,
             value="test@example.com",
             content_object = self.organisation_with_emails,
             preferred=True,
         )
-        # self.email_contact.save()
+        self.email_contact.save()
 
     def test_email_addresses(self):
         self.assertEqual(0, len(self.organisation_without_emails.email_addresses))

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -94,10 +94,10 @@ class OrganisationModelTest(TestCase):
         self.assertTrue(self.ncop_organisation.is_committee)
         self.assertFalse(self.test_organisation.is_committee)
 
-    def test_contactable(self):
-        self.assertTrue(self.na_organisation.contactable)
-        self.assertFalse(self.ncop_organisation.contactable)
-        self.assertFalse(self.test_organisation.contactable)
+    def test_contactable_committee(self):
+        self.assertTrue(self.na_organisation.contactable_committee)
+        self.assertFalse(self.ncop_organisation.contactable_committee)
+        self.assertFalse(self.test_organisation.contactable_committee)
 
     def test_is_ongoing(self):
         self.assertTrue(self.na_organisation.is_ongoing())

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -99,6 +99,29 @@ class OrganisationEmailAddressesTest(TestCase):
 
 
 @attr(country="south_africa")
+class OrganisationOngoingUnitTest(unittest.TestCase):
+    def setUp(self):
+        self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
+        self.organisation_future_ended = Organisation(
+            name="Test Org", slug="test-org", kind=self.test_kind, ended="future"
+        )
+        self.organisation_none_ended = Organisation(
+            name="Basic Education", slug="basic-education", kind=self.test_kind,
+        )
+        self.organisation_already_ended = Organisation(
+            name="NCOP Appropriations",
+            slug="ncop-appropriations",
+            kind=self.test_kind,
+            ended="2010-01-01",
+        )
+
+    def test_is_ongoing(self):
+        self.assertTrue(self.organisation_future_ended.is_ongoing())
+        self.assertTrue(self.organisation_none_ended.is_ongoing())
+        self.assertFalse(self.organisation_already_ended.is_ongoing())
+
+
+@attr(country="south_africa")
 class OrganisationModelTest(TestCase):
     def setUp(self):
         create_organisation_kinds(self)
@@ -130,11 +153,6 @@ class OrganisationModelTest(TestCase):
         self.assertTrue(self.na_organisation.contactable_committee)
         self.assertFalse(self.ncop_organisation.contactable_committee)
         self.assertFalse(self.test_organisation.contactable_committee)
-
-    def test_is_ongoing(self):
-        self.assertTrue(self.na_organisation.is_ongoing())
-        self.assertFalse(self.ncop_organisation.is_ongoing())
-        self.assertTrue(self.test_organisation.is_ongoing())
 
     def test_to_str(self):
         self.assertEqual(

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -1,9 +1,11 @@
+from nose.plugins.attrib import attr
 from django.test import TestCase
 
 from pombola.core import models
 
 from django.contrib.contenttypes.models import ContentType
 
+@attr(country="south_africa")
 class OrganisationTest(TestCase):
     def setUp(self):
         self.organisation_kind = models.OrganisationKind(

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -13,7 +13,30 @@ from django.contrib.contenttypes.models import ContentType
 
 
 @attr(country="south_africa")
-class OrganisationTest(TestCase):
+class OrganisationModelTest(TestCase):
+    def setUp(self):
+        self.organisation_kind = OrganisationKind(name="Foo", slug="foo",)
+        self.organisation_kind.save()
+
+        self.organisation = Organisation(
+            name="Test Org", slug="test-org", kind=self.organisation_kind,
+        )
+        self.organisation.save()
+
+        self.mysociety_id = Identifier.objects.create(
+            identifier="/organisations/1",
+            scheme="org.mysociety.za",
+            object_id=self.organisation.id,
+            content_type=ContentType.objects.get_for_model(Organisation),
+        )
+
+    def testIdentifier(self):
+        org_mysociety_id = self.organisation.get_identifier("org.mysociety.za")
+        self.assertEqual(org_mysociety_id, "/organisations/1")
+
+
+@attr(country="south_africa")
+class OrganisationQuerySetTest(TestCase):
     def create_contact_kinds(self):
         self.email_kind = ContactKind.objects.create(name="Email", slug="email")
         self.phone_kind = ContactKind.objects.create(name="Phone", slug="phone")
@@ -25,14 +48,6 @@ class OrganisationTest(TestCase):
             content_type=ContentType.objects.get_for_model(self.na_organisation),
             object_id=self.na_organisation.id,
             preferred=True,
-        )
-
-    def create_identifiers(self):
-        self.mysociety_id = Identifier.objects.create(
-            identifier="/organisations/1",
-            scheme="org.mysociety.za",
-            object_id=self.test_organisation.id,
-            content_type=ContentType.objects.get_for_model(Organisation),
         )
 
     def setUp(self):
@@ -47,6 +62,7 @@ class OrganisationTest(TestCase):
         self.test_organisation = Organisation.objects.create(
             name="Test Org", slug="test-org", kind=self.foo_kind, ended="future"
         )
+
         self.na_organisation = Organisation.objects.create(
             name="Basic Education", slug="basic-education", kind=self.na_kind,
         )
@@ -56,14 +72,8 @@ class OrganisationTest(TestCase):
             kind=self.ncop_kind,
             ended="2010-01-01",
         )
-
         self.create_contact_kinds()
         self.create_contacts()
-
-    def test_identifier(self):
-        self.create_identifiers()
-        org_mysociety_id = self.test_organisation.get_identifier("org.mysociety.za")
-        self.assertEqual(org_mysociety_id, "/organisations/1")
 
     def test_committees(self):
         result = Organisation.objects.committees().all()

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -13,30 +13,7 @@ from django.contrib.contenttypes.models import ContentType
 
 
 @attr(country="south_africa")
-class OrganisationModelTest(TestCase):
-    def setUp(self):
-        self.organisation_kind = OrganisationKind(name="Foo", slug="foo",)
-        self.organisation_kind.save()
-
-        self.organisation = Organisation(
-            name="Test Org", slug="test-org", kind=self.organisation_kind,
-        )
-        self.organisation.save()
-
-        self.mysociety_id = Identifier.objects.create(
-            identifier="/organisations/1",
-            scheme="org.mysociety.za",
-            object_id=self.organisation.id,
-            content_type=ContentType.objects.get_for_model(Organisation),
-        )
-
-    def testIdentifier(self):
-        org_mysociety_id = self.organisation.get_identifier("org.mysociety.za")
-        self.assertEqual(org_mysociety_id, "/organisations/1")
-
-
-@attr(country="south_africa")
-class OrganisationQuerySetTest(TestCase):
+class OrganisationTest(TestCase):
     def create_contact_kinds(self):
         self.email_kind = ContactKind.objects.create(name="Email", slug="email")
         self.phone_kind = ContactKind.objects.create(name="Phone", slug="phone")
@@ -48,6 +25,14 @@ class OrganisationQuerySetTest(TestCase):
             content_type=ContentType.objects.get_for_model(self.na_organisation),
             object_id=self.na_organisation.id,
             preferred=True,
+        )
+
+    def create_identifiers(self):
+        self.mysociety_id = Identifier.objects.create(
+            identifier="/organisations/1",
+            scheme="org.mysociety.za",
+            object_id=self.test_organisation.id,
+            content_type=ContentType.objects.get_for_model(Organisation),
         )
 
     def setUp(self):
@@ -62,7 +47,6 @@ class OrganisationQuerySetTest(TestCase):
         self.test_organisation = Organisation.objects.create(
             name="Test Org", slug="test-org", kind=self.foo_kind, ended="future"
         )
-
         self.na_organisation = Organisation.objects.create(
             name="Basic Education", slug="basic-education", kind=self.na_kind,
         )
@@ -72,8 +56,14 @@ class OrganisationQuerySetTest(TestCase):
             kind=self.ncop_kind,
             ended="2010-01-01",
         )
+
         self.create_contact_kinds()
         self.create_contacts()
+
+    def test_identifier(self):
+        self.create_identifiers()
+        org_mysociety_id = self.test_organisation.get_identifier("org.mysociety.za")
+        self.assertEqual(org_mysociety_id, "/organisations/1")
 
     def test_committees(self):
         result = Organisation.objects.committees().all()

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -10,8 +10,6 @@ from pombola.core.models import (
     ContactKind,
 )
 
-from django.contrib.contenttypes.models import ContentType
-
 
 @attr(country="south_africa")
 class OrganisationEmailAddressesTest(TestCase):
@@ -51,7 +49,7 @@ class OrganisationEmailAddressesTest(TestCase):
 
 
 @attr(country="south_africa")
-class OrganisationOngoingUnitTest(unittest.TestCase):
+class OrganisationIsOngoingTest(unittest.TestCase):
     def setUp(self):
         self.test_kind = OrganisationKind(name="TestKind", slug="test-kind")
         self.organisation_future_ended = Organisation(
@@ -223,9 +221,9 @@ class OrganisationQuerysetCommitteesTest(TestCase):
 
     def test_committees_filter(self):
         result = Organisation.objects.committees().all()
-        self.assertIn(self.non_committee_org, result)
-        self.assertNotIn(self.ncop_committee, result)
-        self.assertNotIn(self.na_committee, result)
+        self.assertNotIn(self.non_committee_org, result)
+        self.assertIn(self.ncop_committee, result)
+        self.assertIn(self.na_committee, result)
 
 
 @attr(country="south_africa")

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -28,11 +28,6 @@ class OrganisationModelTest(TestCase):
         org_mysociety_id = self.organisation.get_identifier("org.mysociety.za")
         self.assertEqual(org_mysociety_id, "/organisations/1")
 
-    def tearDown(self):
-        self.mysociety_id.delete()
-        self.organisation.delete()
-        self.organisation_kind.delete()
-
 
 @attr(country="south_africa")
 class OrganisationQuerySetTest(TestCase):

--- a/pombola/settings/south_africa_base.py
+++ b/pombola/settings/south_africa_base.py
@@ -18,7 +18,7 @@ BLOG_RSS_FEED = ''
 
 BREADCRUMB_URL_NAME_MAPPINGS = {
     'info': ['Information', '/info/'],
-    'organisation': ['People', '/organisation/all/'],
+    'organisation': ['Organisations', '/organisation/all/'],
     'person': ['Politicians', '/person/all/'],
     'place': ['Places', '/place/all/'],
     'search': ['Search', '/search/'],

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -3558,3 +3558,6 @@ ul.attendance__notes {
     }
 
 }
+.committee-list-house h2 {
+  color: #e23d28;
+}

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -3558,6 +3558,7 @@ ul.attendance__notes {
     }
 
 }
+
 .committee-list-house h2 {
-  color: #e23d28;
+  color: $colour_terracotta;
 }

--- a/pombola/south_africa/templates/core/organisation_detail.html
+++ b/pombola/south_africa/templates/core/organisation_detail.html
@@ -36,16 +36,14 @@
 
   {% endif %}
 
-  {% if contactable_via_writeinpublic %}
-    
-
-    <div class="contact-actions">
-      <div class="contact-actions__wip">
+  <div class="contact-actions">
+    <div class="contact-actions__wip">
+        {% if object.contactable %}
           <a href="{% url 'writeinpublic-committees:writeinpublic-new-message' %}?person_id={{ object.pk }}">Write a public message to this committee</a>
-          <a href="{% url 'organisation_messages' slug=object.slug %}" class="contact-actions__wip__view-link">View messages</a>
-      </div>
+        {% endif %}
+        <a href="{% url 'organisation_messages' slug=object.slug %}" class="contact-actions__wip__view-link">View messages</a>
     </div>
-  {% endif %}
+  </div>
 
   <h2>People</h2>
 

--- a/pombola/south_africa/templates/core/organisation_detail.html
+++ b/pombola/south_africa/templates/core/organisation_detail.html
@@ -38,7 +38,7 @@
 
   <div class="contact-actions">
     <div class="contact-actions__wip">
-        {% if object.contactable %}
+        {% if object.contactable_committee %}
           <a href="{% url 'writeinpublic-committees:writeinpublic-new-message' %}?person_id={{ object.pk }}">Write a public message to this committee</a>
         {% endif %}
         <a href="{% url 'organisation_messages' slug=object.slug %}" class="contact-actions__wip__view-link">View messages</a>

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -34,7 +34,7 @@
                 
                   <div class="committee-list__links">
                       <a href="{% url 'organisation_messages' slug=committee.slug %}">View messages</a>
-                      {% if committee.contactable %}
+                      {% if committee.contactable_committee %}
                         <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
                       {% endif %}
                   </div>

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -1,47 +1,47 @@
 {% extends 'base.html' %}
 {% load pagination_tags %}
+{% load pipeline %}
+
+{% block js_end_of_body %}
+  {{ block.super }}
+  {% javascript 'hide-reveal' %}
+{% endblock %}
 
 {% block title %}{% if kind %}{{ kind.name }}{% endif %}{% endblock %}
 
 {% block content %}
 
     <h1 class="page-title">
-        {% if kind %}
-            {{ kind.name }}
-        {% else %}
-            Committees
-        {% endif %}
+        Committees
     </h1>
 
-    {% if committees %}
+    {% regroup committees by kind.name as houses %}
+    {% for house in houses %}
+    <div>
+        <a class="committee-list-house js-hide-reveal-link hide-reveal-link has-dropdown-dark" href="#{{ house.grouper|slugify }}">
+            <h2> {{ house.grouper }} </h2>
+        </a>
 
-        {% autopaginate committees %}
+        <div class="js-hide-reveal" id="{{ house.grouper|slugify }}">
+          <ul class="unstyled-list committee-list">
+            {% for committee in house.list %}
+              <li class="list-of-things-item {{ committee.css_class }}-list-item{% if not committee.show_active %} inactive{% endif %}">
+                  <p>
+                      <a href="{{ committee.get_absolute_url }}" class="committee-list__name">
+                      {{ committee.short_name }}
+                      </a>
+                  </p>
+                
+                  <div class="committee-list__links">
+                      <a href="{% url 'organisation_messages' slug=committee.slug %}">View messages</a>
+                      <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
+                  </div>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+    </div>
+    {% endfor %}
 
-        <ul class="unstyled-list committee-list">
-
-        {% for committee in committees %}
-        <li class="list-of-things-item {{ committee.css_class }}-list-item{% if not committee.show_active %} inactive{% endif %}">
-            <p>
-                <a href="{{ committee.get_absolute_url }}" class="committee-list__name">
-                {{ committee.short_name }}
-                </a>
-            </p>
-           
-            <div class="committee-list__links">
-                <a href="{% url 'organisation_messages' slug=committee.slug %}">View messages</a>
-                <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
-            </div>
-        </li>
-        {% endfor %}
-
-        </ul>
-
-        {% include "core/_search_pagination_text.html" %}
-
-        {% paginate %}
-
-    {% else %}
-        <p>No committees were found</p>
-    {% endif %}
 
 {% endblock %}

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -34,7 +34,9 @@
                 
                   <div class="committee-list__links">
                       <a href="{% url 'organisation_messages' slug=committee.slug %}">View messages</a>
-                      <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
+                      {% if committee.contactable %}
+                        <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
+                      {% endif %}
                   </div>
               </li>
             {% endfor %}

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -22,7 +22,7 @@
             <h2> {{ house.grouper }} </h2>
         </a>
 
-        <div class="js-hide-reveal" id="{{ house.grouper|slugify }}">
+        <div class="js-hide-reveal" id="{{ house.grouper|slugify }}" style="display:none">
           <ul class="unstyled-list committee-list">
             {% for committee in house.list %}
               <li class="list-of-things-item {{ committee.css_class }}-list-item{% if not committee.show_active %} inactive{% endif %}">

--- a/pombola/south_africa/templates/south_africa/committee_list.html
+++ b/pombola/south_africa/templates/south_africa/committee_list.html
@@ -7,7 +7,7 @@
   {% javascript 'hide-reveal' %}
 {% endblock %}
 
-{% block title %}{% if kind %}{{ kind.name }}{% endif %}{% endblock %}
+{% block title %}Committees{% endblock %}
 
 {% block content %}
 

--- a/pombola/south_africa/templates/writeinpublic/committee-messages.html
+++ b/pombola/south_africa/templates/writeinpublic/committee-messages.html
@@ -20,11 +20,11 @@
       </li>
   {% empty %}
     <p>No messages have been sent to {{ committee.name }}.</p>
-    {% if committee.contactable %}
-      <p>
-        <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
-      </p>
-    {% endif %}
   {% endfor %}
   </ul>
+  {% if committee.contactable %}
+    <p>
+      <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a new public message</a>
+    </p>
+  {% endif %}
 {% endblock %}

--- a/pombola/south_africa/templates/writeinpublic/committee-messages.html
+++ b/pombola/south_africa/templates/writeinpublic/committee-messages.html
@@ -22,7 +22,7 @@
     <p>No messages have been sent to {{ committee.name }}.</p>
   {% endfor %}
   </ul>
-  {% if committee.contactable %}
+  {% if committee.contactable_committee %}
     <p>
       <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a new public message</a>
     </p>

--- a/pombola/south_africa/templates/writeinpublic/committee-messages.html
+++ b/pombola/south_africa/templates/writeinpublic/committee-messages.html
@@ -19,10 +19,12 @@
         
       </li>
   {% empty %}
-    {% comment %}
-      TODO: Just hide this panel completely if there are no messages?
-    {% endcomment %}
-    <p>Nothing here!</p>
+    <p>No messages have been sent to {{ committee.name }}.</p>
+    {% if committee.contactable %}
+      <p>
+        <a href="{% url 'writeinpublic-committees:writeinpublic-new-message-step' step='recipients' %}?person_id={{ committee.pk }}">Write a public message</a>
+      </p>
+    {% endif %}
   {% endfor %}
   </ul>
 {% endblock %}

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1658,6 +1658,50 @@ class SAHansardIndexViewTest(TestCase):
 
 @attr(country='south_africa')
 class SACommitteeIndexViewTest(WebTest):
+    def setUp(self):
+        # Create the houses
+        self.org_kind_na_committee = models.OrganisationKind.objects.create(
+            name='National Assembly Committees',
+            slug='national-assembly-committees'
+        )
+        self.org_kind_ncop_committee = models.OrganisationKind.objects.create(
+            name='NCOP',
+            slug='ncop-committees'
+        )
+        # Create the committees
+        self.na_org = models.Organisation.objects.create(
+            slug='committee-communications',
+            name='PC on Communications',
+            kind=self.org_kind_na_committee
+        )
+        self.ncop_org = models.Organisation.objects.create(
+            slug='committee-finance',
+            name='Select Committee in Finance',
+            kind=self.org_kind_ncop_committee
+        )
+        # Create email addresses for committees
+        self.email_kind = models.ContactKind.objects.create(name='Email', slug='email')
+        self.na_org.contacts.create(
+            kind=self.email_kind, value='na-test@example.org', preferred=False)
+        self.ncop_org.contacts.create(
+            kind=self.email_kind, value='ncop-test@example.org', preferred=False)
+
+    def test_committee_index_page(self):
+        response = self.app.get('/committees/')
+        self.assertEqual(response.status_code, 200)
+
+        # Check that committee kind names are in response
+        self.assertContains(response, self.org_kind_na_committee.name)
+        self.assertContains(response, self.org_kind_ncop_committee.name)
+
+        # Check that committee names are in response
+        self.assertContains(response, self.na_org.name)
+        self.assertContains(response, self.ncop_org.name)
+
+        # TODO: Check which ones are writetable
+
+@attr(country='south_africa')
+class SACommitteeHansardsViewTest(WebTest):
 
     def setUp(self):
         self.fish_section_heading = u"Oh fishy fishy fishy fishy fishy fish"
@@ -1709,7 +1753,7 @@ class SACommitteeIndexViewTest(WebTest):
             },
         ], instance=default_instance)
 
-    def test_committee_index_page(self):
+    def test_committee_minutes_page(self):
         response = self.app.get('/committee-minutes/')
         self.assertEqual(response.status_code, 200)
 

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -2803,12 +2803,22 @@ class SACommitteesPopoloJSONTest(TestCase):
             name='National Assembly Committees',
             slug='national-assembly-committees'
         )
-        org = models.Organisation.objects.create(
+        org_kind_ncop_committee = models.OrganisationKind.objects.create(
+            name='NCOP',
+            slug='ncop-committees'
+        )
+        na_org = models.Organisation.objects.create(
             slug='committee-communications',
             name='PC on Communications',
             kind=org_kind_na_committee
         )
-        org.contacts.create(kind=self.email_kind, value='test@example.org', preferred=False)
+        ncop_org = models.Organisation.objects.create(
+            slug='committee-finance',
+            name='Select Committee in Finance',
+            kind=org_kind_ncop_committee
+        )
+        na_org.contacts.create(kind=self.email_kind, value='na-test@example.org', preferred=False)
+        ncop_org.contacts.create(kind=self.email_kind, value='ncop-test@example.org', preferred=False)
 
         response = self.client.get('/api/committees/popolo.json')
         self.assertEquals(response.status_code, 200)
@@ -2817,9 +2827,15 @@ class SACommitteesPopoloJSONTest(TestCase):
             'persons': [
                 {
                     'contact_details': [],
-                    'email': 'test@example.org',
-                    'id': str(org.id),
+                    'email': 'na-test@example.org',
+                    'id': str(na_org.id),
                     'name': 'PC on Communications'
+                },
+                {
+                    'contact_details': [],
+                    'email': 'ncop-test@example.org',
+                    'id': str(ncop_org.id),
+                    'name': 'Select Committee in Finance'
                 }
             ]
         }

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1661,7 +1661,7 @@ class SACommitteeIndexViewTest(WebTest):
     def setUp(self):
         # Create the houses
         self.org_kind_na_committee = models.OrganisationKind.objects.create(
-            name='National Assembly Committees',
+            name='National Assembly',
             slug='national-assembly-committees'
         )
         self.org_kind_ncop_committee = models.OrganisationKind.objects.create(
@@ -2847,7 +2847,7 @@ class SACommitteesPopoloJSONTest(TestCase):
 
     def test_produces_correct_json_with_contacts(self):
         org_kind_na_committee = models.OrganisationKind.objects.create(
-            name='National Assembly Committees',
+            name='National Assembly',
             slug='national-assembly-committees'
         )
         org_kind_ncop_committee = models.OrganisationKind.objects.create(

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1683,8 +1683,6 @@ class SACommitteeIndexViewTest(WebTest):
         self.email_kind = models.ContactKind.objects.create(name='Email', slug='email')
         self.na_org.contacts.create(
             kind=self.email_kind, value='na-test@example.org', preferred=False)
-        # self.ncop_org.contacts.create(
-        #     kind=self.email_kind, value='ncop-test@example.org', preferred=False)
 
     def test_committee_index_page(self):
         response = self.app.get('/committees/')

--- a/pombola/south_africa/tests.py
+++ b/pombola/south_africa/tests.py
@@ -1813,29 +1813,6 @@ class SAOrganisationDetailViewTest(WebTest):
 
 
 @attr(country='south_africa')
-class SAOrganisationDetailViewWriteInPublicTest(TestCase):
-    def setUp(self):
-        na_committee_kind = models.OrganisationKind.objects.create(name='National Assembly Committees', slug='national-assembly-committees')
-        self.committee = models.Organisation.objects.create(slug='test-committee', kind=na_committee_kind)
-
-    def test_not_contactable_via_writeinpublic_with_no_email(self):
-        response = self.client.get(reverse('organisation', kwargs={'slug': self.committee.slug}))
-        self.assertFalse(response.context['contactable_via_writeinpublic'])
-
-    def test_contactable_via_writeinpublic_with_email(self):
-        email_contact_kind = models.ContactKind.objects.create(name='Email', slug='email')
-        self.committee.contacts.create(kind=email_contact_kind, value='test@example.com', preferred=False)
-        response = self.client.get(reverse('organisation', kwargs={'slug': self.committee.slug}))
-        self.assertTrue(response.context['contactable_via_writeinpublic'])
-
-    def test_contactable_via_writeinpublic_not_committee(self):
-        org_kind = models.OrganisationKind.objects.create(name='Test', slug='test')
-        org = models.Organisation.objects.create(slug='test-org', kind=org_kind)
-        response = self.client.get(reverse('organisation', kwargs={'slug': org.slug}))
-        self.assertFalse(response.context['contactable_via_writeinpublic'])
-
-
-@attr(country='south_africa')
 class SAOrganisationDetailViewTestParliament(WebTest):
 
     def setUp(self):

--- a/pombola/south_africa/views/api.py
+++ b/pombola/south_africa/views/api.py
@@ -5,12 +5,10 @@ from pombola.core.models import Person, Organisation, Position
 
 
 # Output Popolo JSON suitable for WriteInPublic for any committees that have an
-# email address.
+# email address and is ongoing.
 class CommitteesPopoloJson(ListView):
-    queryset = Organisation.objects.filter(
-        kind__name='National Assembly Committees',
-        contacts__kind__slug='email'
-    )
+    queryset = Organisation.objects.prefetch_related('contacts__kind')\
+        .committees().ongoing().has_email_contacts()
 
     def render_to_response(self, context, **response_kwargs):
         return JsonResponse(
@@ -19,7 +17,7 @@ class CommitteesPopoloJson(ListView):
                     {
                         'id': str(committee.id),
                         'name': committee.short_name,
-                        'email': committee.contacts.filter(kind__slug='email')[0].value,
+                        'email': committee.email_addresses[0].value,
                         'contact_details': []
                     }
                     for committee in context['object_list']

--- a/pombola/south_africa/views/api.py
+++ b/pombola/south_africa/views/api.py
@@ -8,7 +8,7 @@ from pombola.core.models import Person, Organisation, Position
 # email address and is ongoing.
 class CommitteesPopoloJson(ListView):
     queryset = Organisation.objects.prefetch_related('contacts__kind')\
-        .committees().ongoing().has_email_contacts()
+        .contactable().distinct()
 
     def render_to_response(self, context, **response_kwargs):
         return JsonResponse(

--- a/pombola/south_africa/views/api.py
+++ b/pombola/south_africa/views/api.py
@@ -8,7 +8,7 @@ from pombola.core.models import Person, Organisation, Position
 # email address and is ongoing.
 class CommitteesPopoloJson(ListView):
     queryset = Organisation.objects.prefetch_related('contacts__kind')\
-        .contactable().distinct()
+        .contactable_committees().distinct()
 
     def render_to_response(self, context, **response_kwargs):
         return JsonResponse(

--- a/pombola/south_africa/views/committees.py
+++ b/pombola/south_africa/views/committees.py
@@ -4,11 +4,8 @@ from pombola.core.models import Organisation, OrganisationKind
 
 
 class SACommitteesView(ListView):
-    # .filter(
-    #     contacts__kind__slug='email'
-    # )
     queryset = Organisation.objects.committees()\
-        .ongoing().select_related('kind').order_by('kind__id').all()
+        .select_related('kind').order_by('kind__id').all()
     context_object_name = 'committees'
     template_name = 'south_africa/committee_list.html'
 

--- a/pombola/south_africa/views/committees.py
+++ b/pombola/south_africa/views/committees.py
@@ -5,7 +5,8 @@ from pombola.core.models import Organisation, OrganisationKind
 
 class SACommitteesView(ListView):
     queryset = Organisation.objects.committees()\
-        .select_related('kind').order_by('kind__id').all()
+        .select_related('kind').prefetch_related('contacts__kind')\
+        .order_by('kind__id').all()
     context_object_name = 'committees'
     template_name = 'south_africa/committee_list.html'
 

--- a/pombola/south_africa/views/committees.py
+++ b/pombola/south_africa/views/committees.py
@@ -4,14 +4,14 @@ from pombola.core.models import Organisation, OrganisationKind
 
 
 class SACommitteesView(ListView):
-    queryset = Organisation.objects.filter(
-        kind__name='National Assembly Committees',
-        contacts__kind__slug='email'
-    ).distinct().order_by('short_name')
+    # .filter(
+    #     contacts__kind__slug='email'
+    # )
+    queryset = Organisation.objects.committees()\
+        .ongoing().select_related('kind').order_by('kind__id').all()
     context_object_name = 'committees'
     template_name = 'south_africa/committee_list.html'
 
     def get_context_data(self, *args, **kwargs):
         context = super(SACommitteesView, self).get_context_data(*args, **kwargs)
-        context['kind'] = OrganisationKind.objects.get(name='National Assembly Committees')
         return context

--- a/pombola/south_africa/views/organisations.py
+++ b/pombola/south_africa/views/organisations.py
@@ -63,11 +63,6 @@ class SAOrganisationDetailView(CommentArchiveMixin, OrganisationDetailView):
         except EmptyPage:
             context['positions'] = paginator.page(paginator.num_pages)
 
-        # Determine if this org is a committee that can be contacted
-        context['contactable_via_writeinpublic'] = \
-            self.object.kind.name == 'National Assembly Committees' \
-            and self.object.contacts.filter(kind__slug='email').exists()
-
         return context
 
     def add_parliament_counts_to_context_data(self, context):

--- a/pombola/writeinpublic/fields.py
+++ b/pombola/writeinpublic/fields.py
@@ -43,3 +43,8 @@ class GroupedModelChoiceField(ModelChoiceField):
         return GroupedModelChoiceIterator(self, groupby=self.choices_groupby)
 
     choices = property(_get_choices, ChoiceField._set_choices)
+
+
+class CommiteeGroupedModelChoiceField(GroupedModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.name

--- a/pombola/writeinpublic/fields.py
+++ b/pombola/writeinpublic/fields.py
@@ -1,0 +1,45 @@
+from functools import partial
+from itertools import groupby
+from operator import attrgetter
+
+from django.forms.models import ModelChoiceIterator, ModelChoiceField, ChoiceField
+
+
+class GroupedModelChoiceIterator(ModelChoiceIterator):
+    def __init__(self, field, groupby):
+        if isinstance(groupby, str):
+            groupby = attrgetter(groupby)
+        elif not callable(groupby):
+            raise TypeError(
+                "choices_groupby must either be a str or a callable accepting a single argument"
+            )
+        self.groupby = groupby
+        super(GroupedModelChoiceIterator, self).__init__(field)
+
+    def __iter__(self):
+        if self.field.empty_label is not None:
+            yield ("", self.field.empty_label)
+        queryset = self.queryset
+        # Can't use iterator() when queryset uses prefetch_related()
+        if not queryset._prefetch_related_lookups:
+            queryset = queryset.iterator()
+        for group, objs in groupby(queryset, self.groupby):
+            yield (group, [self.choice(obj) for obj in objs])
+
+
+class GroupedModelChoiceField(ModelChoiceField):
+    """
+    A ModelChoiceField that is grouped by some value using the choices_groupby
+    argument.
+
+    Copied and modified from https://code.djangoproject.com/ticket/27331
+    """
+
+    def __init__(self, choices_groupby, queryset, *args, **kwargs):
+        self.choices_groupby = choices_groupby
+        super(GroupedModelChoiceField, self).__init__(queryset, *args, **kwargs)
+
+    def _get_choices(self):
+        return GroupedModelChoiceIterator(self, groupby=self.choices_groupby)
+
+    choices = property(_get_choices, ChoiceField._set_choices)

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -314,7 +314,7 @@ class WriteToCommitteeMessagesViewTest(TestCase):
         self.na_committee = Organisation.objects.create(
             slug='test-na-committee', name='NA Test Committee', kind=na_kind)
         self.ncop_committee = Organisation.objects.create(
-            slug='test-ncop-committee', name='NCOP Test Comittee', kind=ncop_kind)
+            slug='test-ncop-committee', name='NCOP Test Committee', kind=ncop_kind)
         email_kind, _ = ContactKind.objects.get_or_create(slug='email', name='Email')
         self.na_committee.contacts.create(
             kind=email_kind, 
@@ -375,10 +375,14 @@ class WriteToCommitteeMessagesViewTest(TestCase):
         response = self.client.get(response.url)
         self.assertEquals(response.status_code, 200)
 
-        self.assertContains(
+        self.assertContains(response, "National Assembly")
+        self.assertContains(response, "NCOP")
+        self.assertContains(response, "NA Test Committee")
+        # Does not contain the house in brackets 
+        self.assertNotContains(
             response, "NA Test Committee (National Assembly)"
         )
-        self.assertContains(response, "NCOP Test Comittee (NCOP)")
+        self.assertContains(response, "NCOP Test Committee")
 
         # POST to the recipients step
         response = self.client.post(
@@ -507,7 +511,7 @@ class CommitteeAdapterTest(TestCase):
     def test_get_form_kwargs_when_committee_has_multiple_emails(self):
         adapter = CommitteeAdapter()
 
-        na_committee_kind = OrganisationKind.objects.create(name='National Assembly Committees', slug='national-assembly-committees')
+        na_committee_kind = OrganisationKind.objects.create(name='National Assembly', slug='national-assembly-committees')
         email_kind = ContactKind.objects.create(name='Email', slug='email')
         committee = Organisation.objects.create(kind=na_committee_kind)
         committee.contacts.create(kind=email_kind, value='test@example.org', preferred=False)

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -375,8 +375,60 @@ class WriteToCommitteeMessagesViewTest(TestCase):
         response = self.client.get(response.url)
         self.assertEquals(response.status_code, 200)
 
-        self.assertContains(response, "{} ({})".format(self.na_committee.name, "National Assembly"))
-        self.assertContains(response, "{} ({})".format(self.ncop_committee.name, "NCOP"))
+        self.assertContains(
+            response, "NA Test Committee (National Assembly)"
+        )
+        self.assertContains(response, "NCOP Test Comittee (NCOP)")
+
+        # POST to the recipients step
+        response = self.client.post(
+            reverse(
+                'writeinpublic-committees:writeinpublic-new-message-step', 
+                kwargs={'step': 'recipients'}
+            ), {
+                'write_in_public_new_message-current_step': 'recipients',
+                'recipients-persons': self.na_committee.id,
+            }
+        )
+
+        self.assertRedirects(
+            response, 
+            reverse(
+                'writeinpublic-committees:writeinpublic-new-message-step', 
+                kwargs={'step': 'draft'}
+            ))
+
+        # GET the draft step
+        response = self.client.get(response.url)
+        self.assertEquals(response.status_code, 200)
+        self.assertContains(
+            response, "NA Test Committee (National Assembly)"
+        )
+        self.assertNotContains(response, "NCOP Test Comittee (NCOP)")
+
+        # POST to the draft step
+        response = self.client.post(
+            reverse('writeinpublic-committees:writeinpublic-new-message-step', 
+            kwargs={'step': 'draft'}), 
+            {
+                'write_in_public_new_message-current_step': 'draft',
+                'draft-subject': 'Test',
+                'draft-content': 'Test',
+                'draft-author_name': 'Test',
+                'draft-author_email': 'test@example.com',
+            }
+        )
+        self.assertRedirects(
+            response, 
+            reverse(
+                'writeinpublic-committees:writeinpublic-new-message-step', 
+                kwargs={'step': 'preview'}
+            )
+        )
+
+        # GET the preview step
+        response = self.client.get(response.url)
+        self.assertEquals(response.status_code, 200)
 
 
 

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -73,7 +73,7 @@ class CommitteeAdapter(object):
     def get_form_kwargs(self, step=None):
         queryset = Organisation.objects.prefetch_related('contacts__kind')\
             .select_related('kind')\
-            .contactable().distinct().order_by('kind_id')
+            .contactable_committees().distinct().order_by('kind_id')
         
         choicefield = CommiteeGroupedModelChoiceField(
             choices_groupby='kind.name',

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -55,11 +55,6 @@ class PersonAdapter(object):
         return {}
 
 
-class CommitteeModelChoiceField(ModelChoiceField):
-    def label_from_instance(self, obj):
-        return obj.short_name
-
-
 class CommitteeAdapter(object):
     def filter(self, ids):
         return Organisation.objects.filter(id__in=ids)

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -14,7 +14,7 @@ import logging
 from pombola.core.models import Person, Organisation, Position
 
 from .forms import RecipientForm, DraftForm, PreviewForm, ModelChoiceField
-from .fields import GroupedModelChoiceField
+from .fields import CommiteeGroupedModelChoiceField
 from .client import WriteInPublic
 from .models import Configuration
 
@@ -75,7 +75,7 @@ class CommitteeAdapter(object):
             .select_related('kind')\
             .contactable().distinct().order_by('kind_id')
         
-        choicefield = GroupedModelChoiceField(
+        choicefield = CommiteeGroupedModelChoiceField(
             choices_groupby='kind.name',
             queryset=queryset,
             empty_label=None


### PR DESCRIPTION
Enable writing to ad-hoc, NCOP and joint committees in addition to National Assembly committees.

[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/172714248)

Changes:
- [x] Shows all committees on pa.org.za/committees/
- [x] Shows "Write to committee" button on pa.org.za/committees/ only if the committee is ongoing and we have an email address for them
- [x] Shows "Write to committee" button on a committee's page (e.g. pa.org.za/organisation/constitutional-review-committee/) only if the committee is ongoing and we have an email address for them
- [x] Returns all committees which are ongoing and which we have an email address for in pa.org.za/api/committees/popolo.json
- [x] Change the recipients drop-down to group committees by their houses like on PMG

Drop-down on the [recipients](https://www.pa.org.za/write/recipients/) page:

![2020-09-03-09:27](https://user-images.githubusercontent.com/4767109/92084560-dff6f500-edc7-11ea-9507-db0c20a2bd3b.png)

Committees page:

![2020-08-26-09:29](https://user-images.githubusercontent.com/4767109/91274302-c417a180-e77e-11ea-99a7-16bb46d2528b.png)

![2020-08-26-09:30](https://user-images.githubusercontent.com/4767109/91274340-d396ea80-e77e-11ea-83d5-ef933bc78971.png)

Draft page:

![2020-09-03-09:02](https://user-images.githubusercontent.com/4767109/92082090-627db580-edc4-11ea-9282-ac4f81492b35.png)


Preview page:

![2020-09-03-09:02_1](https://user-images.githubusercontent.com/4767109/92082102-66113c80-edc4-11ea-8b74-6eb8254d94eb.png)

