### PR TITLE
Don't cache write in public views

### DIFF
--- a/pombola/south_africa/static/sass/_person-write.scss
+++ b/pombola/south_africa/static/sass/_person-write.scss
@@ -17,6 +17,7 @@
     label {
         display: block;
         margin-bottom: 0.5em;
+        float: left;
 
         small {
             display: block;
@@ -102,6 +103,13 @@
         & > :last-child {
             margin-bottom: 0;
         }
+    }
+
+    .change-recipients {
+      border: 1px solid $colour_terracotta;
+      color: $colour_terracotta;
+      background-color: white;
+      padding: 2px;
     }
 }
 

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-draft.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-draft.html
@@ -8,6 +8,7 @@
 
     <p class="form-group">
         <label for="recipients">To</label>
+        <a class="button pull-right change-recipients" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='recipients' %}">Change recipients</a>
         <input type="text" disabled id="recipients" value="{{ persons }}">
     </p>
 
@@ -49,7 +50,6 @@
         </div>
     </div>
 
-    <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='recipients' %}">Change recipients</a>
     <input type="submit" value="Preview message" class="button pull-right">
 </form>
 {% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-draft.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-draft.html
@@ -20,6 +20,7 @@
 
     <p class="form-group">
         <label for="recipients">To</label>
+        <a class="button pull-right change-recipients" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='recipients' %}">Change recipients</a>
         <input type="text" disabled id="recipients" value="{{ persons | join:", " }}">
     </p>
 
@@ -61,7 +62,6 @@
         </div>
     </div>
 
-    <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='recipients' %}">Change recipients</a>
     <input type="submit" value="Preview message" class="button pull-right">
 </form>
 {% endblock %}

--- a/pombola/writeinpublic/urls.py
+++ b/pombola/writeinpublic/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url
 from django.views.generic import TemplateView
+from django.views.decorators.cache import never_cache
+from django.views.decorators.cache import cache_page
 
 from . import views
 
@@ -9,22 +11,22 @@ write_message_wizard = views.WriteInPublicNewMessage.as_view(url_name='writeinpu
 urlpatterns = (
     url(
         r'^pending/$',
-        TemplateView.as_view(template_name='writeinpublic/pending.html'),
+        cache_page(0)(TemplateView.as_view(template_name='writeinpublic/pending.html')),
         name='writeinpublic-pending',
     ),
     url(
         r'^message/(?P<message_id>\d+)/$',
-        views.WriteInPublicMessage.as_view(),
+        cache_page(0)(views.WriteInPublicMessage.as_view()),
         name='writeinpublic-message'
     ),
     url(
         r'^(?P<step>.+)/$',
-        write_message_wizard,
+        cache_page(0)(write_message_wizard),
         name='writeinpublic-new-message-step',
     ),
     url(
         r'^$',
-        write_message_wizard,
+        cache_page(0)(write_message_wizard),
         name='writeinpublic-new-message',
     ),
 )

--- a/pombola/writeinpublic/urls.py
+++ b/pombola/writeinpublic/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 from django.views.generic import TemplateView
-from django.views.decorators.cache import cache_page
+from django.views.decorators.cache import never_cache
 
 from . import views
 
@@ -10,22 +10,22 @@ write_message_wizard = views.WriteInPublicNewMessage.as_view(url_name='writeinpu
 urlpatterns = (
     url(
         r'^pending/$',
-        cache_page(0)(TemplateView.as_view(template_name='writeinpublic/pending.html')),
+        never_cache(TemplateView.as_view(template_name='writeinpublic/pending.html')),
         name='writeinpublic-pending',
     ),
     url(
         r'^message/(?P<message_id>\d+)/$',
-        cache_page(0)(views.WriteInPublicMessage.as_view()),
+        views.WriteInPublicMessage.as_view(),
         name='writeinpublic-message'
     ),
     url(
         r'^(?P<step>.+)/$',
-        cache_page(0)(write_message_wizard),
+        never_cache(write_message_wizard),
         name='writeinpublic-new-message-step',
     ),
     url(
         r'^$',
-        cache_page(0)(write_message_wizard),
+        never_cache(write_message_wizard),
         name='writeinpublic-new-message',
     ),
 )

--- a/pombola/writeinpublic/urls.py
+++ b/pombola/writeinpublic/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import url
 from django.views.generic import TemplateView
-from django.views.decorators.cache import never_cache
 from django.views.decorators.cache import cache_page
 
 from . import views


### PR DESCRIPTION
1. Don't cache write in public pages

  We cache all pages by [default](https://github.com/OpenUpSA/pombola/blob/master/pombola/settings/base.py#L195) for 1200 seconds (20 mins), including the write in public pages. We can exclude them by setting their timeout to 0.

2. Move "Change Recipients" button to the "To" section so that it is easier to spot.

  On a larger screen:

  ![2020-09-07-14:33_1](https://user-images.githubusercontent.com/4767109/92388433-8ff59680-f117-11ea-98d4-411c0de41195.png)

  On a smaller screen:

  ![2020-09-07-14:33](https://user-images.githubusercontent.com/4767109/92388444-9257f080-f117-11ea-9a61-6190f15324b4.png)


[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/174087008)