### PR TITLE
Order committees by house

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -784,7 +784,7 @@ class OrganisationKind(ModelBase):
         return ('organisation_kind', (self.slug,))
 
 
-COMMITTEE_HOUSE_SLUGS = [
+COMMITTEE_GROUP_SLUGS = [
     'national-assembly-committees',
     'ncop-committees',
     'joint-committees',
@@ -794,21 +794,21 @@ COMMITTEE_HOUSE_SLUGS = [
 class OrganisationQuerySet(models.query.GeoQuerySet):
     def order_by_house(self):
         """
-        Order the organisation queryset according to the COMMITTEE_HOUSE_SLUGS list.
+        Order the organisation queryset according to the COMMITTEE_GROUP_SLUGS list.
 
         Copied from: https://stackoverflow.com/a/37648265/3486675
         """
         preserved = Case(
             *[
                 When(kind__slug=slug, then=pos)
-                for pos, slug in enumerate(COMMITTEE_HOUSE_SLUGS)
+                for pos, slug in enumerate(COMMITTEE_GROUP_SLUGS)
             ]
         )
 
         return self.order_by(preserved)
 
     def committees(self):
-        return self.filter(kind__slug__in=COMMITTEE_HOUSE_SLUGS)
+        return self.filter(kind__slug__in=COMMITTEE_GROUP_SLUGS)
 
     def ongoing(self):
         """
@@ -917,7 +917,7 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
     
     @property
     def is_committee(self):
-        return self.kind.slug in COMMITTEE_HOUSE_SLUGS
+        return self.kind.slug in COMMITTEE_GROUP_SLUGS
 
     @property
     def contactable_committee(self):

--- a/pombola/core/tests/test_organisations.py
+++ b/pombola/core/tests/test_organisations.py
@@ -191,6 +191,12 @@ class OrganisationQuerysetCommitteesTest(TestCase):
         self.ncop_kind = OrganisationKind.objects.create(
             name="NCOP", slug="ncop-committees"
         )
+        self.joint_kind = OrganisationKind.objects.create(
+            name="Joint Committees", slug="joint-committees"
+        )
+        self.ad_hoc_kind = OrganisationKind.objects.create(
+            name="Ad-hoc Committees", slug="ad-hoc-committees"
+        )
 
         self.non_committee_org = Organisation.objects.create(
             name="Non-committee",
@@ -210,12 +216,42 @@ class OrganisationQuerysetCommitteesTest(TestCase):
             kind=self.na_kind,
             ended="future",
         )
+        self.ad_hoc_committee = Organisation.objects.create(
+            name="Ad Hoc Committee on the Appointment of the Auditor General",
+            slug="ad-hoc-auditor-general",
+            kind=self.ad_hoc_kind,
+            ended="future",
+        )
+        self.joint_committee = Organisation.objects.create(
+            name="Joint Standing Committee on Defence",
+            slug="joint-defence",
+            kind=self.joint_kind,
+            ended="future",
+        )
 
     def test_committees_filter(self):
         result = Organisation.objects.committees().all()
+        committees = [
+            self.ncop_committee,
+            self.na_committee,
+            self.joint_committee,
+            self.ad_hoc_committee,
+        ]
+        for committee in committees:
+            self.assertIn(committee, result)
         self.assertNotIn(self.non_committee_org, result)
-        self.assertIn(self.ncop_committee, result)
-        self.assertIn(self.na_committee, result)
+
+    def test_order_by_house(self):
+        result = Organisation.objects.order_by_house().all()
+        expected_ordering = [
+            self.na_committee,
+            self.ncop_committee,
+            self.joint_committee,
+            self.ad_hoc_committee,
+            self.non_committee_org,
+        ]
+        for i, organisation in enumerate(expected_ordering):
+            self.assertEqual(result[i], organisation)
 
 
 class OrganisationQuerysetOngoingTest(unittest.TestCase):

--- a/pombola/south_africa/views/committees.py
+++ b/pombola/south_africa/views/committees.py
@@ -6,7 +6,7 @@ from pombola.core.models import Organisation, OrganisationKind
 class SACommitteesView(ListView):
     queryset = Organisation.objects.committees()\
         .select_related('kind').prefetch_related('contacts__kind')\
-        .order_by('kind__id').all()
+        .order_by_house().all()
     context_object_name = 'committees'
     template_name = 'south_africa/committee_list.html'
 

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -68,7 +68,8 @@ class CommitteeAdapter(object):
     def get_form_kwargs(self, step=None):
         queryset = Organisation.objects.prefetch_related('contacts__kind')\
             .select_related('kind')\
-            .contactable_committees().distinct().order_by('kind_id')
+            .contactable_committees().distinct()\
+            .order_by_house()
         
         choicefield = CommiteeGroupedModelChoiceField(
             choices_groupby='kind.name',


### PR DESCRIPTION
Ordering committees by house according to PMG's preference: NA Committees, NCOP Committees, Joint Committees, Ad hoc Committees.

Order committees in the drop-down on https://www.pa.org.za/write-committees/recipients/ and on https://pa.org.za/committees/

[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/172714248)