### PR TITLE
Add admin action to bulk mark feedback as spam

### DIFF
--- a/pombola/feedback/admin.py
+++ b/pombola/feedback/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
+from django.contrib import messages
 from pombola.feedback.models import Feedback
+from django.utils.translation import ngettext
 
 @admin.register(Feedback)
 class FeedbackAdmin(admin.ModelAdmin):
@@ -10,3 +12,14 @@ class FeedbackAdmin(admin.ModelAdmin):
     ordering = ('-created',)
     raw_id_fields = ('user',)
     search_fields = ('comment', 'user__username', 'url', 'email')
+    actions = ['mark_as_spammy']
+
+    def mark_as_spammy(self, request, queryset):
+        updated = queryset.update(status='spammy')
+        self.message_user(request, ngettext(
+            '%d feedback item was successfully marked as spam.',
+            '%d feedback items were successfully marked as spam.',
+            updated,
+        ) % updated, messages.SUCCESS)
+
+    mark_as_spammy.short_description = "Mark selected feedback as spam"


### PR DESCRIPTION
Add an admin action to the feedback list to easily mark a bunch of feedback items as spam.

![screen](https://user-images.githubusercontent.com/4767109/95380497-2075f100-08e7-11eb-9727-1d56cfc3554c.png)
