### PR TITLE
Exclude 'sorl.thumbnail.base' errors from sentry logging

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -675,9 +675,18 @@ if os.environ.get("SENTRY_DSN"):
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
 
+		def before_send(event, hint):
+			"""Don't log sorl.thumbnail.base errors in Sentry."""
+			if 'log_record' in hint:
+				if hint['log_record'].name == 'sorl.thumbnail.base':
+					return None
+			return event
+
     sentry_sdk.init(
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
+
+				before_send=before_send
 
         # Associate users to errors
         send_default_pii=True

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -672,22 +672,22 @@ DEBUG_TOOLBAR_CONFIG = {
 
 # Sentry
 if os.environ.get("SENTRY_DSN"):
-    import sentry_sdk
-    from sentry_sdk.integrations.django import DjangoIntegration
+  import sentry_sdk
+  from sentry_sdk.integrations.django import DjangoIntegration
 
-		def before_send(event, hint):
-			"""Don't log sorl.thumbnail.base errors in Sentry."""
-			if 'log_record' in hint:
-				if hint['log_record'].message == 'missing file_ argument in get_thumbnail()':
-					return None
-			return event
+	def before_send(event, hint):
+		"""Don't log sorl.thumbnail.base errors in Sentry."""
+		if 'log_record' in hint:
+			if hint['log_record'].message == 'missing file_ argument in get_thumbnail()':
+				return None
+		return event
 
-    sentry_sdk.init(
-        dsn=os.environ.get("SENTRY_DSN"),
-        integrations=[DjangoIntegration()],
+	sentry_sdk.init(
+			dsn=os.environ.get("SENTRY_DSN"),
+			integrations=[DjangoIntegration()],
 
-				before_send=before_send,
+			before_send=before_send,
 
-        # Associate users to errors
-        send_default_pii=True
-    )
+			# Associate users to errors
+			send_default_pii=True
+	)

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -686,7 +686,7 @@ if os.environ.get("SENTRY_DSN"):
         dsn=os.environ.get("SENTRY_DSN"),
         integrations=[DjangoIntegration()],
 
-				before_send=before_send
+				before_send=before_send,
 
         # Associate users to errors
         send_default_pii=True

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -678,7 +678,7 @@ if os.environ.get("SENTRY_DSN"):
 		def before_send(event, hint):
 			"""Don't log sorl.thumbnail.base errors in Sentry."""
 			if 'log_record' in hint:
-				if hint['log_record'].name == 'sorl.thumbnail.base':
+				if hint['log_record'].message == 'missing file_ argument in get_thumbnail()':
 					return None
 			return event
 

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -672,22 +672,20 @@ DEBUG_TOOLBAR_CONFIG = {
 
 # Sentry
 if os.environ.get("SENTRY_DSN"):
-  import sentry_sdk
-  from sentry_sdk.integrations.django import DjangoIntegration
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
 
-	def before_send(event, hint):
-		"""Don't log sorl.thumbnail.base errors in Sentry."""
-		if 'log_record' in hint:
-			if hint['log_record'].message == 'missing file_ argument in get_thumbnail()':
-				return None
-		return event
+    def before_send(event, hint):
+        """Don't log sorl.thumbnail.base errors in Sentry."""
+        if 'log_record' in hint:
+            if hint['log_record'].message == 'missing file_ argument in get_thumbnail()':
+                return None
+        return event
 
-	sentry_sdk.init(
-			dsn=os.environ.get("SENTRY_DSN"),
-			integrations=[DjangoIntegration()],
-
-			before_send=before_send,
-
-			# Associate users to errors
-			send_default_pii=True
-	)
+    sentry_sdk.init(
+        dsn=os.environ.get("SENTRY_DSN"),
+        integrations=[DjangoIntegration()],
+        before_send=before_send,
+        # Associate users to errors
+        send_default_pii=True
+    )


### PR DESCRIPTION
Added a `before_send` to sentry init so that we can exclude `sorl.thumbnail.base` errors from being logged. This is a temporary fix, to be reviewed after upgrade of Django.

[Pivotal](https://www.pivotaltracker.com/story/show/175325055)