### PR TITLE
Remove pmg_api_cache directory from tar backup

### DIFF
--- a/bin/backup-data-dir.bash
+++ b/bin/backup-data-dir.bash
@@ -12,5 +12,5 @@ TMP_PATH=/tmp/${TMP_FILENAME}
 
 trap "rm -f ${TMP_PATH}" EXIT
 
-tar -czf ${TMP_PATH} ${POMBOLA_DATADIR}
+tar --exclude=pmg_api_cache -czf ${TMP_PATH} ${POMBOLA_DATADIR}
 aws s3 cp ${TMP_PATH} s3://${BUCKET}/${TMP_FILENAME}

--- a/bin/backup-data-dir.bash
+++ b/bin/backup-data-dir.bash
@@ -12,5 +12,5 @@ TMP_PATH=/tmp/${TMP_FILENAME}
 
 trap "rm -f ${TMP_PATH}" EXIT
 
-tar --exclude=pmg_api_cache -czf ${TMP_PATH} ${POMBOLA_DATADIR}
+tar --exclude=${PMG_API_CACHE_DIR} -czf ${TMP_PATH} ${POMBOLA_DATADIR}
 aws s3 cp ${TMP_PATH} s3://${BUCKET}/${TMP_FILENAME}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -159,7 +159,8 @@ dokku config:set pombola \
     GOOGLE_RECAPTCHA_SITE_KEY=... \
     GOOGLE_RECAPTCHA_SECRET_KEY=... \
     DATA_DIR_BACKUP_AWS_SECRET_ACCESS_KEY=... \
-    DATA_DIR_BACKUP_AWS_ACCESS_KEY_ID=...
+    DATA_DIR_BACKUP_AWS_ACCESS_KEY_ID=... \
+    PMG_API_CACHE_DIR=pmg_api_cache
 
 dokku docker-options:add pombola deploy "-v /var/pombola-data:/data"
 dokku docker-options:add pombola run "-v /var/pombola-data:/data"

--- a/pombola/settings/south_africa.py
+++ b/pombola/settings/south_africa.py
@@ -28,7 +28,8 @@ PIPELINE_JS.update(COUNTRY_JS)
 
 EXCLUDE_FROM_SEARCH = ('places', 'info_pages');
 
-PMG_API_CACHE_PATH = os.path.join(data_dir, 'pmg_api_cache')
+pmg_api_cache_dir = os.environ.get('PMG_API_CACHE_DIR', 'pmg_api_cache')
+PMG_API_CACHE_PATH = os.path.join(data_dir, pmg_api_cache_dir)
 
 try:
     os.makedirs(PMG_API_CACHE_PATH)


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/174846525)

 - Adds an environment variable (`PMG_API_CACHE_DIR`) for the name of the PMG cache directory (currently `pmg_api_cache`).
 - Uses the new environment variable to exclude the directory from the tar archive. 

I checked that the caching of PMG attendances still work after adding the environment variable.