### PR TITLE
Replace custom with Google Recaptcha on Write To pages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ RUN apt-get update && \
                        yui-compressor \
                        zlib1g-dev \
                        postgresql-client \
-                       awscli \
-                       flite
+                       awscli
 
 RUN mkdir /app
 COPY requirements.txt /app/

--- a/pombola/core/static/sass/_captcha.scss
+++ b/pombola/core/static/sass/_captcha.scss
@@ -1,8 +1,0 @@
-.captcha-group {
-  display: flex;
-
-  input[type="text"] {
-    width: 50% !important;
-    margin-left: 0.5em;
-  }
-}

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -459,7 +459,6 @@ INSTALLED_APPS = (
     'django_extensions',
 
     'rest_framework',
-    'captcha'
 )
 if os.environ.get("DJANGO_DEBUG_TOOLBAR", "true").lower() == "true":
     INSTALLED_APPS += ("debug_toolbar",)
@@ -657,8 +656,6 @@ SHELL_PLUS_APP_PREFIXES = {
 }
 
 GOOGLE_MAPS_GEOCODING_API_KEY = os.environ.get("GOOGLE_MAPS_GEOCODING_API_KEY", "")
-
-CAPTCHA_FLITE_PATH = "/usr/bin/flite"
 
 GOOGLE_RECAPTCHA_SITE_KEY = os.environ.get("GOOGLE_RECAPTCHA_SITE_KEY", "")
 GOOGLE_RECAPTCHA_SECRET_KEY = os.environ.get("GOOGLE_RECAPTCHA_SECRET_KEY", "")

--- a/pombola/settings/tests_base.py
+++ b/pombola/settings/tests_base.py
@@ -36,5 +36,3 @@ MAP_BOUNDING_BOX_WEST = None
 # assets, as suggested here:
 #   https://github.com/cyberdelia/django-pipeline/issues/277
 STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
-
-CAPTCHA_TEST_MODE = True

--- a/pombola/south_africa/static/sass/_person-write.scss
+++ b/pombola/south_africa/static/sass/_person-write.scss
@@ -112,9 +112,10 @@
       padding: 2px;
     }
 
-    // Hide the Google Recaptcha element so that the 'Edit' and 'Submit' buttons align
-    #edit-write-to-message + div {
-      display: None;
+    .preview-buttons {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
     }
 }
 

--- a/pombola/south_africa/static/sass/_person-write.scss
+++ b/pombola/south_africa/static/sass/_person-write.scss
@@ -119,6 +119,10 @@
     }
 }
 
+.person-write-form--centered {
+  margin: 0 auto;
+}
+
 // Custom version of the write form, with a coloured background,
 // and a label that looks like a heading.
 .person-write-form--emphasised {

--- a/pombola/south_africa/static/sass/_person-write.scss
+++ b/pombola/south_africa/static/sass/_person-write.scss
@@ -111,6 +111,11 @@
       background-color: white;
       padding: 2px;
     }
+
+    // Hide the Google Recaptcha element so that the 'Edit' and 'Submit' buttons align
+    #edit-write-to-message + div {
+      display: None;
+    }
 }
 
 // Custom version of the write form, with a coloured background,

--- a/pombola/south_africa/static/sass/south-africa.scss
+++ b/pombola/south_africa/static/sass/south-africa.scss
@@ -36,7 +36,6 @@
 @import "info_pages";
 @import "hide-reveal";
 @import "help";
-@import "captcha";
 
 // printer specific
 @import "print";

--- a/pombola/urls.py
+++ b/pombola/urls.py
@@ -157,10 +157,6 @@ urlpatterns += (
 )
 
 
-urlpatterns += (
-    url(r'^captcha/', include('captcha.urls')),
-)
-
 # URL to check that the Sentry integration is working
 def trigger_error(request):
     division_by_zero = 1 / 0

--- a/pombola/writeinpublic/forms.py
+++ b/pombola/writeinpublic/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.forms import SelectMultiple, ModelMultipleChoiceField, ModelChoiceField
-from captcha.fields import CaptchaField
 
 from pombola.core.models import Person
 
@@ -29,4 +28,4 @@ class DraftForm(forms.Form):
 
 
 class PreviewForm(forms.Form):
-    captcha = CaptchaField()
+    pass

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-draft.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-draft.html
@@ -53,3 +53,6 @@
     <input type="submit" value="Preview message" class="button pull-right">
 </form>
 {% endblock %}
+
+{% block correct_this_page %}
+{% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
@@ -43,7 +43,7 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
+    <a id="edit-write-to-message" class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
     {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
       <input 
         type="submit" value="Send message"

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
@@ -43,16 +43,18 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <a id="edit-write-to-message" class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
-    {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
-      <input 
-        type="submit" value="Send message"
-        class="g-recaptcha button pull-right"
-        data-sitekey="{{ settings.GOOGLE_RECAPTCHA_SITE_KEY }}"
-        data-callback='onSubmitMessage'>
-    {% else %}
-      <input type="submit" value="Send message" class="button pull-right">
-    {% endif %}
+    <div class='preview-buttons'>
+      <a id="edit-write-to-message" class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
+      {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
+        <input 
+          type="submit" value="Send message"
+          class="g-recaptcha button pull-right"
+          data-sitekey="{{ settings.GOOGLE_RECAPTCHA_SITE_KEY }}"
+          data-callback='onSubmitMessage'>
+      {% else %}
+        <input type="submit" value="Send message" class="button pull-right">
+      {% endif %}
+    </div>
 </form>
 {% endblock %}
 

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
@@ -55,3 +55,6 @@
     {% endif %}
 </form>
 {% endblock %}
+
+{% block correct_this_page %}
+{% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
@@ -1,8 +1,22 @@
 {% extends "base.html" %}
 
+{% block js_end_of_body %}
+  {{ block.super }}
+  {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
+    <script>
+       function onSubmitMessage(token) {
+         document.getElementById("submitMessage").submit();
+       }
+     </script>
+  {% endif %}
+{% endblock %}
+
 {% block title %}Preview of message to {{ object.name }}{% endblock %}
 
 {% block content %}
+
+{% include 'writeinpublic/flash_messages.html' %}
+
 <div class="person-write-thread">
     <div class="person-write-message">
         <dl class="person-write-message__meta">
@@ -21,7 +35,7 @@
     </div>
 </div>
 
-<form action="" method="post" class="person-write-form">{% csrf_token %}
+<form id="submitMessage" action="" method="post" class="person-write-form">{% csrf_token %}
     {{ wizard.management_form }}
 
     <div class="privacy-reminder">
@@ -29,16 +43,15 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <div class="row">
-      <p class="form-group">
-          <label for="{{ form.captcha.auto_id }}">Please enter the text you see below or click on the image to hear an audio version:</label>
-          <div class="captcha-group">
-            {{form.captcha}}
-          </div>
-      </p>
-    </p>
-
     <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
-    <input type="submit" value="Send message" class="button pull-right">
+    {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
+      <input 
+        type="submit" value="Send message"
+        class="g-recaptcha button pull-right"
+        data-sitekey="{{ settings.GOOGLE_RECAPTCHA_SITE_KEY }}"
+        data-callback='onSubmitMessage'>
+    {% else %}
+      <input type="submit" value="Send message" class="button pull-right">
+    {% endif %}
 </form>
 {% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-preview.html
@@ -35,7 +35,7 @@
     </div>
 </div>
 
-<form id="submitMessage" action="" method="post" class="person-write-form">{% csrf_token %}
+<form id="submitMessage" action="" method="post" class="person-write-form person-write-form--centered">{% csrf_token %}
     {{ wizard.management_form }}
 
     <div class="privacy-reminder">

--- a/pombola/writeinpublic/templates/writeinpublic/committee-write-recipients.html
+++ b/pombola/writeinpublic/templates/writeinpublic/committee-write-recipients.html
@@ -47,3 +47,6 @@
     <input type="submit" value="Draft message" class="button pull-right">
 </form>
 {% endblock %}
+
+{% block correct_this_page %}
+{% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-draft.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-draft.html
@@ -65,3 +65,6 @@
     <input type="submit" value="Preview message" class="button pull-right">
 </form>
 {% endblock %}
+
+{% block correct_this_page %}
+{% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -43,15 +43,6 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <div class="row">
-      <p class="form-group">
-          <label for="{{ form.captcha.auto_id }}">Please enter the text you see below or click on the image to hear an audio version:</label>
-          <div class="captcha-group">
-            {{form.captcha}}
-          </div>
-      </p>
-    </p>
-
     <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
     {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
       <input 

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -43,7 +43,7 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
+    <a id="edit-write-to-message" class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
     {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
       <input 
         type="submit" value="Send message"

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -14,6 +14,9 @@
 {% block title %}Preview of message to {{ object.name }}{% endblock %}
 
 {% block content %}
+
+{% include 'writeinpublic/flash_messages.html' %}
+
 <div class="person-write-thread">
     <div class="person-write-message">
         <dl class="person-write-message__meta">

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -55,3 +55,6 @@
     {% endif %}
 </form>
 {% endblock %}
+
+{% block correct_this_page %}
+{% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -43,16 +43,18 @@
       <p>Once you send this message, it will be available on the Internet for anyone to read. Your name will be included alongside the message. Your email address will not be public.</p>
     </div>
 
-    <a id="edit-write-to-message" class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
-    {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
-      <input 
-        type="submit" value="Send message"
-        class="g-recaptcha button pull-right"
-        data-sitekey="{{ settings.GOOGLE_RECAPTCHA_SITE_KEY }}"
-        data-callback='onSubmitMessage'>
-    {% else %}
-      <input type="submit" value="Send message" class="button pull-right">
-    {% endif %}
+    <div class='preview-buttons'>
+      <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
+      {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
+        <input 
+          type="submit" value="Send message"
+          class="g-recaptcha button pull-right"
+          data-sitekey="{{ settings.GOOGLE_RECAPTCHA_SITE_KEY }}"
+          data-callback='onSubmitMessage'>
+      {% else %}
+        <input type="submit" value="Send message" class="button pull-right">
+      {% endif %}
+    </div>
 </form>
 {% endblock %}
 

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -35,7 +35,7 @@
     </div>
 </div>
 
-<form id="submitMessage" action="" method="post" class="person-write-form">{% csrf_token %}
+<form id="submitMessage" action="" method="post" class="person-write-form person-write-form--centered">{% csrf_token %}
     {{ wizard.management_form }}
 
     <div class="privacy-reminder">

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-preview.html
@@ -1,5 +1,16 @@
 {% extends "base.html" %}
 
+{% block js_end_of_body %}
+  {{ block.super }}
+  {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
+    <script>
+       function onSubmitMessage(token) {
+         document.getElementById("submitMessage").submit();
+       }
+     </script>
+  {% endif %}
+{% endblock %}
+
 {% block title %}Preview of message to {{ object.name }}{% endblock %}
 
 {% block content %}
@@ -21,7 +32,7 @@
     </div>
 </div>
 
-<form action="" method="post" class="person-write-form">{% csrf_token %}
+<form id="submitMessage" action="" method="post" class="person-write-form">{% csrf_token %}
     {{ wizard.management_form }}
 
     <div class="privacy-reminder">
@@ -39,6 +50,14 @@
     </p>
 
     <a class="button secondary-button" href="{% url 'writeinpublic:writeinpublic-new-message-step' step='draft' %}">Edit message</a>
-    <input type="submit" value="Send message" class="button pull-right">
+    {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
+      <input 
+        type="submit" value="Send message"
+        class="g-recaptcha button pull-right"
+        data-sitekey="{{ settings.GOOGLE_RECAPTCHA_SITE_KEY }}"
+        data-callback='onSubmitMessage'>
+    {% else %}
+      <input type="submit" value="Send message" class="button pull-right">
+    {% endif %}
 </form>
 {% endblock %}

--- a/pombola/writeinpublic/templates/writeinpublic/person-write-recipients.html
+++ b/pombola/writeinpublic/templates/writeinpublic/person-write-recipients.html
@@ -56,3 +56,6 @@
     <input type="submit" value="Draft message" class="button pull-right">
 </form>
 {% endblock %}
+
+{% block correct_this_page %}
+{% endblock %}

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -7,6 +7,8 @@ from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.utils.dateparse import parse_datetime
 from django.forms import ModelMultipleChoiceField, ModelChoiceField
+from django.test.utils import override_settings
+from mock import patch
 
 from pombola.core.models import Person, Organisation, OrganisationKind, ContactKind
 
@@ -217,6 +219,88 @@ class ClientTest(TestCase):
 
 @requests_mock.Mocker()
 class WriteInPublicNewMessageViewTest(TestCase):
+    @override_settings(GOOGLE_RECAPTCHA_SECRET_KEY=None)
+    def test_sending_message_wizard_steps_works_without_recaptcha(self, m):
+        # TODO
+        pass
+
+    @override_settings(GOOGLE_RECAPTCHA_SECRET_KEY='test-key')
+    @patch('pombola.writeinpublic.views.recaptcha_client')
+    def test_sending_message_wizard_steps_raises_error_with_incorrect_recaptcha(self, m, mocked_recaptcha_client):
+        mocked_recaptcha_client.verify.return_value = False
+        # Mock the POST response
+        m.post('/api/v1/message/', json={
+            'id': '42'
+        })
+        m.get('/api/v1/person/', json=person_json)
+        configuration = Configuration.objects.create(
+            url='http://example.com',
+            username='admin',
+            api_key='test',
+            instance_id='1',
+            slug='south-africa-assembly'
+        )
+        person = Person.objects.create()
+        parliament = OrganisationKind.objects.create(slug='parliament', name='Parliament')
+        na = Organisation.objects.create(slug='national-assembly', name='National Assembly', kind=parliament)
+        person.position_set.create(organisation=na)
+        ck_email, _ = ContactKind.objects.get_or_create(slug='email', name='Email')
+        person.contacts.create(kind=ck_email, value='test@example.com', preferred=True)
+        response = self.client.get(reverse('writeinpublic:writeinpublic-new-message'))
+        self.assertRedirects(response, reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'recipients'}))
+
+        # GET the recipients step
+        response = self.client.get(response.url)
+        self.assertEquals(response.status_code, 200)
+
+        # POST to the recipients step
+        response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'recipients'}), {
+            'write_in_public_new_message-current_step': 'recipients',
+            'recipients-persons': person.id,
+        })
+
+        self.assertRedirects(response, reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'draft'}))
+
+        # GET the draft step
+        response = self.client.get(response.url)
+        self.assertEquals(response.status_code, 200)
+
+        # POST to the draft step
+        response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'draft'}), {
+            'write_in_public_new_message-current_step': 'draft',
+            'draft-subject': 'Test',
+            'draft-content': 'Test',
+            'draft-author_name': 'Test',
+            'draft-author_email': 'test@example.com',
+        })
+        self.assertRedirects(response, reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'preview'}))
+
+        # GET the preview step
+        response = self.client.get(response.url)
+        self.assertEquals(response.status_code, 200)
+
+        # POST to the preview step
+        response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'preview'}), {
+            'write_in_public_new_message-current_step': 'preview',
+        }, follow=True
+        )
+
+        # After unsuccessful Recaptcha, return to the preview page
+        self.assertRedirects(
+            response,
+            reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'preview'}),
+            fetch_redirect_response=False
+        )
+        
+        # Check that the error message is in the context
+        message = list(response.context['messages'])[0]
+        self.assertEqual(message.tags, "error")
+        expected_message = 'Sorry, there was an error sending your message, please try again. If this problem persists please contact us.'
+        self.assertTrue(expected_message in message.message)
+
+
+    @override_settings(GOOGLE_RECAPTCHA_SECRET_KEY=None)
+    @patch('pombola.writeinpublic.views.recaptcha_client')
     def test_sending_message_wizard_steps(self, m):
         # Mock the POST response
         m.post('/api/v1/message/', json={

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -272,8 +272,6 @@ class WriteInPublicNewMessageViewTest(TestCase):
         # POST to the preview step
         response = self.client.post(reverse('writeinpublic:writeinpublic-new-message-step', kwargs={'step': 'preview'}), {
             'write_in_public_new_message-current_step': 'preview',
-            'preview-captcha_0': 'random-string',
-            'preview-captcha_1': 'PASSED'
         })
         self.assertRedirects(
             response,

--- a/pombola/writeinpublic/tests.py
+++ b/pombola/writeinpublic/tests.py
@@ -411,7 +411,7 @@ class WriteToCommitteeMessagesViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['messages'], [])
 
-    def test_sending_message_wizard_steps(self, m):
+    def _test_successful_sending_message_wizard_steps(self, mock_requests):
         # GET the new message redirect
         response = self.client.get(
             reverse('writeinpublic-committees:writeinpublic-new-message'))
@@ -499,7 +499,7 @@ class WriteToCommitteeMessagesViewTest(TestCase):
             "Are you happy for this message to be made public?")
 
         # Mock the POST response
-        m.post('/api/v1/message/', json={
+        mock_requests.post('/api/v1/message/', json={
             'id': '42'
         })
 
@@ -533,6 +533,10 @@ class WriteToCommitteeMessagesViewTest(TestCase):
             reverse('writeinpublic-committees:writeinpublic-pending'),
             fetch_redirect_response=False
         )
+
+    @override_settings(GOOGLE_RECAPTCHA_SECRET_KEY=None)
+    def test_sending_message_wizard_steps(self, mock_requests):
+        self._test_successful_sending_message_wizard_steps(mock_requests)
 
 
 

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -167,7 +167,6 @@ class WriteInPublicNewMessage(WriteInPublicMixin, NamedUrlSessionWizardView):
                 if not recaptcha_client.verify(recaptcha_response):
                     messages.error(self.request, 'Sorry, there was an error sending your message, please try again. If this problem persists please contact us.')
                     return redirect(self.get_step_url(self.steps.current))
-                    # TODO: redirect with message
 
         return super(WriteInPublicNewMessage, self).post(*args, **kwargs)
 

--- a/pombola/writeinpublic/views.py
+++ b/pombola/writeinpublic/views.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from formtools.wizard.views import NamedUrlSessionWizardView
 
 from django.views.generic import TemplateView
@@ -12,6 +11,7 @@ from django.core.urlresolvers import reverse
 import logging
 
 from pombola.core.models import Person, Organisation, Position
+from pombola.core.recaptcha import recaptcha_client
 
 from .forms import RecipientForm, DraftForm, PreviewForm, ModelChoiceField
 from .fields import CommiteeGroupedModelChoiceField
@@ -137,32 +137,6 @@ class WriteInPublicMixin(object):
         self.request.current_app = self.request.resolver_match.namespace
         return super(WriteInPublicMixin, self).render_to_response(context, **response_kwargs)
 
-class PreventRevalidationMixin(object):
-    """
-    Mixin to prevent the revalidation of specific fields.
-
-    From https://github.com/jazzband/django-formtools/issues/21.
-
-    Added because the Captcha field can't be validated more than once.
-
-    Add the mixin and an array of NO_REVALIDATION_FIELD_NAMES that you don't 
-    want to be revalidated at the end of the wizard.
-    """
-    def process_step(self, form):
-        for name in self.NO_REVALIDATION_FIELD_NAMES:
-           if name in form.fields:
-               self.storage.extra_data['skip_validation_%s' % name] = True
-        return super(PreventRevalidationMixin, self).process_step(form)
-
-    def get_form(self, step=None, *args, **kwargs):
-        # From https://github.com/jazzband/django-formtools/issues/21
-        form = super(PreventRevalidationMixin, self).get_form(step=step, *args, **kwargs)
-        for name in self.NO_REVALIDATION_FIELD_NAMES:
-           if name in form.fields and self.storage.extra_data.get('skip_validation_%s' % name):
-                del form.fields[name]
-        return form
-
-
 
 FORMS = [
     ("recipients", RecipientForm),
@@ -171,8 +145,7 @@ FORMS = [
 ]
 
 
-class WriteInPublicNewMessage(WriteInPublicMixin, PreventRevalidationMixin, NamedUrlSessionWizardView):
-    NO_REVALIDATION_FIELD_NAMES = ['captcha']
+class WriteInPublicNewMessage(WriteInPublicMixin, NamedUrlSessionWizardView):
     form_list = FORMS
 
     def get_form_kwargs(self, step=None):
@@ -185,8 +158,22 @@ class WriteInPublicNewMessage(WriteInPublicMixin, PreventRevalidationMixin, Name
         else:
             return super(WriteInPublicNewMessage, self).get_form_initial(step=step)
 
+    def post(self, request, *args, **kwargs):
+        step = kwargs.get('step')
+        if step == 'preview':
+            # Verify Recaptcha
+            if settings.GOOGLE_RECAPTCHA_SECRET_KEY:
+                recaptcha_response = request.POST.get("g-recaptcha-response", "")
+                if not recaptcha_client.verify(recaptcha_response):
+                    messages.error(self.request, 'Sorry, there was an error sending your message, please try again. If this problem persists please contact us.')
+                    return redirect(self.get_step_url(self.steps.current))
+                    # TODO: redirect with message
+
+        return super(WriteInPublicNewMessage, self).post(*args, **kwargs)
+
     def get(self, *args, **kwargs):
         step = kwargs.get('step')
+
         # If we have an ID in the URL and it matches someone, go straight to
         # /draft
         if 'person_id' in self.request.GET:
@@ -198,6 +185,7 @@ class WriteInPublicNewMessage(WriteInPublicMixin, PreventRevalidationMixin, Name
                 return redirect(self.get_step_url('draft'))
             except Person.DoesNotExist:
                 pass
+
 
         # Check that the form contains valid data
         if step == 'draft' or step == 'preview':

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,9 +171,6 @@ cffi
 everypolitician==0.0.13
 everypolitician-popolo==0.0.11
 
-# Captcha
-django-simple-captcha==0.5.12
-
 # Streaming Excel files for contact list download
 xlsx-streaming==0.4.1
 zipstream==1.1.4


### PR DESCRIPTION
Things done:
- [x] Replace custom captcha with invisible Google Recaptcha (usually invisible to users, more familiar and less to maintain for us).
- [x] Remove "Correct this page" button from Write To pages because it can confuse users.
- [x] Show flash message when preview page is submitted without valid Recaptcha value.
- [x] Align "Edit" and "Submit" buttons on preview pages.
- [x] Update tests to check that Recaptcha is submitted before continuing to "done" page.
 
Preview page buttons before changes:
![2020-11-13-10:02](https://user-images.githubusercontent.com/4767109/99043794-6afa2580-2597-11eb-8254-7d242d8941b1.png)

After changes:

![2020-11-13-10:23](https://user-images.githubusercontent.com/4767109/99045583-3d62ab80-259a-11eb-9243-679aeef80b48.png)



Flash message when Recaptcha was not submitted:
![2020-11-13-09:51](https://user-images.githubusercontent.com/4767109/99042700-e064f680-2595-11eb-868f-a28f873d68a2.png)


[Pivotal](https://www.pivotaltracker.com/n/projects/2397264/stories/175638834)

For reference:
#6 is the PR where we originally added the custom captcha to write to pages.