### PR TITLE
Use sorl thumbnail for survey image

### DIFF
--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -118,7 +118,9 @@
         <div class="home__news__row">
           {% if survey %}
             <div class="home__news__survey">
-                <img class="home__news__survey__thumb" src="{{ survey.image.url }}" />
+                {% thumbnail survey.image "80x80" crop="center" as sm %}
+                  <img src="{{ sm.url }}" class="home__news__survey__thumb" />
+                {% endthumbnail %}
                 <p><a href="{{ survey.url }}" class="button button--low-case">Have Your Say!</a></p>
             </div>
           {% endif %}


### PR DESCRIPTION
Use sorl `thumbnail` to display the survey image because the `Survey` model [uses](https://github.com/OpenUpSA/pombola/blob/master/pombola/surveys/models.py#L8) sorl's `ImageField`.

When using `thumbnail` the cache URL to the image gets generated correctly. Not sure why it wasn't being generated correctly without `thumbnail`.

[Pivotal](https://www.pivotaltracker.com/story/show/176086875)