### PR TITLE
Fix survey image

### DIFF
--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -133,7 +133,7 @@ USE_L10N = True
 MEDIA_ROOT = os.path.normpath(os.path.join(data_dir, 'media_root/'))
 
 # All uploaded files world-readable
-FILE_UPLOAD_PERMISSIONS = 420  # 644 in octal, 'rw-r--r--'
+FILE_UPLOAD_PERMISSIONS = 0o644  # 'rw-r--r--'
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -132,6 +132,9 @@ USE_L10N = True
 # Example: "/home/media/media.lawrence.com/media/"
 MEDIA_ROOT = os.path.normpath(os.path.join(data_dir, 'media_root/'))
 
+# All uploaded files world-readable
+FILE_UPLOAD_PERMISSIONS = 420  # 644 in octal, 'rw-r--r--'
+
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash.
 # Examples: "http://media.lawrence.com/media/", "http://example.com/media/"

--- a/pombola/south_africa/templates/home.html
+++ b/pombola/south_africa/templates/home.html
@@ -118,9 +118,7 @@
         <div class="home__news__row">
           {% if survey %}
             <div class="home__news__survey">
-                {% thumbnail survey.image "345x345" crop="center" as sm %}
-                  <img src="{{ sm.url }}" class="home__news__survey__thumb" />
-                {% endthumbnail %}
+                <img class="home__news__survey__thumb" src="{{ survey.image.url }}" />
                 <p><a href="{{ survey.url }}" class="button button--low-case">Have Your Say!</a></p>
             </div>
           {% endif %}


### PR DESCRIPTION
- Revert previous changes to survey image on home page
- Set the default [`FILE_UPLOAD_PERMISSIONS`](https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-FILE_UPLOAD_PERMISSIONS) setting to make uploaded files readable.

[Pivotal](https://www.pivotaltracker.com/story/show/176086875)