### PR TITLE
fix dropdown issues and get rid of Jquery related errors

### DIFF
--- a/pombola/core/static/js/functions.js
+++ b/pombola/core/static/js/functions.js
@@ -2,32 +2,32 @@ $(function () {
   /*
    * auto complete
    */
-  const search_input = $('input.search-autocomplete-name');
-  if (search_input.length) {
-    search_input.each(function () {
-      var element = $(this);
-      var source = element.data('source') || "/search/autocomplete/";
-      element && element.autocomplete && element.autocomplete({
-        source: source,
-        minLength: 2,
-        html: true,
-        select: function (event, ui) {
-          if (ui.item) return window.location = ui.item.url;
-        }
-      });
-      element.data('uiAutocomplete')._renderItem = function (ul, item) {
-        var itemElement = $('<li>'), imageElement = $('<img>');
-        imageElement.attr('src', item.image_url);
-        imageElement.attr('width', '16');
-        imageElement.attr('height', '16');
-        itemElement.append(imageElement).append(' ' + item.name);
-        if (item.extra_data) {
-          itemElement.append(' ').append($('<i>').append(item.extra_data));
-        }
-        return itemElement.appendTo(ul);
-      };
+  const searchInput = $('input.search-autocomplete-name');
+  searchInput.each(function () {
+    var element = $(this);
+    var source = element.data('source') || "/search/autocomplete/";
+    element.autocomplete({
+      source: source,
+      minLength: 2,
+      html: true,
+      select: function (event, ui) {
+        if (ui.item) return window.location = ui.item.url;
+      }
     });
-  }
+    const elementAutocomplete = element.data('uiAutocomplete');
+    elementAutocomplete._renderItem = function (ul, item) {
+      var itemElement = $('<li>'), imageElement = $('<img>');
+      imageElement.attr('src', item.image_url);
+      imageElement.attr('width', '16');
+      imageElement.attr('height', '16');
+      itemElement.append(imageElement).append(' ' + item.name);
+      if (item.extra_data) {
+        itemElement.append(' ').append($('<i>').append(item.extra_data));
+      }
+      return itemElement.appendTo(ul);
+    };
+  });
+
 
   // auto-advance cycles through featured MPs; it also immediately replaces the
   // featured MP in the page (since we assume that has been frozen by caching)

--- a/pombola/core/static/sass/_jquery-ui.structure.scss
+++ b/pombola/core/static/sass/_jquery-ui.structure.scss
@@ -171,8 +171,8 @@
 
 .ui-autocomplete {
   position: absolute;
-  top: 0;
-  left: 0;
+  width: inherit;
+  max-width: 380px;
   cursor: default;
 }
 

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -683,6 +683,11 @@ menu#mobile-top-tools,
             background-color: #eee;
         }
     }
+
+    input:focus {
+        border: none;
+        outline: none;
+    }
 }
 
 .tertiary-menu {

--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -140,7 +140,8 @@
         {% block js_end_of_body %}
 
 
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
+        <script src="https://code.jquery.com/jquery-migrate-3.0.0.min.js"></script>
         <script src="//www.google.com/jsapi"></script>
         {% if settings.GOOGLE_RECAPTCHA_SITE_KEY %}
         <script src="https://www.google.com/recaptcha/api.js" async defer></script>
@@ -148,7 +149,6 @@
         {% javascript 'base' %}
         {% javascript 'survey' %}
         <!-- bootstrap stuff -->
-        <script src="https://code.jquery.com/jquery-3.2.1.min.js" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
         <!-- bootstrap stuff -->


### PR DESCRIPTION
These js errors happened as a result of bumping up Jquery to 3.2.1

What is included in this PR:
1. Remove older Jquery
2. Add a Jquery migrate - https://github.com/jquery/jquery-migrate - which basically restores APIs that could have been deprecated in newer Jquery libraries.
3. Fixed the drop down element on the search button.


# Error:
![Screenshot from 2021-11-08 15-19-22](https://user-images.githubusercontent.com/6994982/140741179-6a77cd78-603a-4c72-9615-3ce9d387498f.png)

# After fixing:
![Screenshot from 2021-11-08 15-14-41](https://user-images.githubusercontent.com/6994982/140741228-951e31ed-1f92-4b0d-9d4a-a848e979f0c4.png)
