### PR TITLE
manually match members details whose names could not be automatically matched

### DIFF
--- a/pombola/south_africa/data/members-interests/2020_for_import.json
+++ b/pombola/south_africa/data/members-interests/2020_for_import.json
@@ -304,6 +304,256 @@
             }
         ],
         "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Zia Holdings",
+                "Type of Business Activity": "Automotive"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Apartment",
+                "Extent of the Property": "80m2",
+                "Location \u2013 Area": "Durban"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "Nil",
+                "Name of Trust": "Shaik-Emam",
+                "Registration \nNumber": "IT000829/2019(D)",
+                "Trustee/Beneficiary": "S Munzoor \nR Desai \nT Ahmed \nAM Shaik-Emam"
+            }
+        ],
+        "person": {
+            "slug": "ahmed-munzoor-shaik-emam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
             "slug": "albert-mammoga-seabi"
         },
         "release": {
@@ -1303,6 +1553,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "altia-sthembile-hlongo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "None",
                 "Source": "None"
             }
@@ -1913,6 +2413,256 @@
         ],
         "person": {
             "slug": "amos-fish-mahlalela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "anastasia-motaung"
         },
         "release": {
             "date": "2020-12-31",
@@ -2718,6 +3468,256 @@
         ],
         "person": {
             "slug": "angela-thokozile-didiza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private \nPrivate",
+                "Source": "1. Old Mutual (retirement annuity) 2. Sanlam Sky (retirement annuity)"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "annacleta-mathapelo-siwisa"
         },
         "release": {
             "date": "2020-12-31",
@@ -3596,6 +4596,516 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "3 bedroomed House",
+                "Extent of the Property": "3 bedrooms",
+                "Location \u2013 Area": "Nelspruit"
+            },
+            {
+                "Description of Property": "2 bedroomed House",
+                "Extent of the Property": "2 bedrooms",
+                "Location \u2013 Area": "Nelspruit"
+            },
+            {
+                "Description of Property": "4 bedroomed House",
+                "Extent of the Property": "4 bedrooms",
+                "Location \u2013 Area": "kaSiboshwa"
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "archibold-jomo-nyambi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Nil",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "Nil",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Nil",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Nil",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Nil",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Parliament"
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Nil",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "Nil",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "armand-benjamin-cloete"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "NONE",
                 "Source": "NONE"
             }
@@ -4138,6 +5648,256 @@
         ],
         "person": {
             "slug": "audrey-dimakatso-maleka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "494 Long Homes Greytown",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "Location"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "audrey-sbongile-zuma"
         },
         "release": {
             "date": "2020-12-31",
@@ -4886,6 +6646,260 @@
         ],
         "person": {
             "slug": "babalwa-mathulelwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Fuzberry Solutions (Pty) Ltd",
+                "Type of Business Activity": "Trading in all aspects"
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "POBF"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Old Mutual"
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "bafuze-sicelo-yabo"
         },
         "release": {
             "date": "2020-12-31",
@@ -6170,6 +8184,1006 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "ALL 6 PREVIOUS DIRECTORSHPS RESIGNED IN 2014 OR EARLIER.",
+                "Type of Business Activity": "CLOSE CORPORATIONS AND \nPRIVATE/NON PROFIT COMPANIES LINKED TO MY SENIOR POSITION AT UNIVERSITY OF WITWATERSRAND AND NATIONAL\n                    RESEARCH \nFOUNDATION"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "APARTMENT",
+                "Extent of the Property": "85 SQ M",
+                "Location \u2013 Area": "TAMBOERSKLOOF, CAPE TOWN"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PRIVATE \nPRIVATE",
+                "Source": "WITS UNIVERSITY \nPARLIAMENT (PENDING \u2013 NOT PAID OUT)"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "ALLAN GRAY \nOLD MUTUAL \nLIBERTY \nSTANLIB",
+                "Nature": "PRIVATE \nPRIVATE \nPRIVATE \nPRIVATE",
+                "Nominal Value": "TOTAL: R9.543M",
+                "Number of Shares": "UNIT TRUST \nUNIT TRUST \nUNIT TRUST \nUNIT TRUST"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NONE",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "belinda-bozzoli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "nil",
+                "Source": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "nil",
+                "Type of Business \nActivity": "nil",
+                "Value of any Benefits \nderived": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "nil",
+                "Name of State Entity": "nil",
+                "Period of Contract": "nil",
+                "Value of \nContract": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "RHJ Farm Investments CC (15% \nmember\u2019s interest)",
+                "Type of Business Activity": "Farming activities"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "nil",
+                "Source": "nil",
+                "Value": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "A Section in Wembley \nSquare",
+                "Extent of the Property": "462Meters",
+                "Location \u2013 Area": "Gardens, Cape Town"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "nil",
+                "Source": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "nil",
+                "Type of Business": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "nil",
+                "Nature": "nil",
+                "Nominal Value": "nil",
+                "Number of Shares": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "nil",
+                "Extent": "nil",
+                "Source of Sponsorship": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "nil",
+                "Sponsor": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "nil",
+                "Name of Trust": "nil",
+                "Registration \nNumber": "nil",
+                "Trustee/Beneficiary": "nil"
+            }
+        ],
+        "person": {
+            "slug": "benedicta-maria-van-minnen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "None",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business Activity": "None",
+                "Value of any Benefits derived": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management thereof": "None",
+                "Name of State Entity": "None",
+                "Period of Contract": "None",
+                "Value of \nContract": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Director",
+                "Type of Business Activity": "Tomberry Trading Enterprises: Consulting, training, supply and delivery etc"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "None",
+                "Value": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Private home",
+                "Extent of the Property": "Residenial home",
+                "Location \u2013 Area": "Nelspruit, Mpumalanga"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "None",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "None",
+                "Nature": "None",
+                "Nominal Value": "None",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "None.",
+                "Extent": "None",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "None",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "None",
+                "Name of Trust": "None",
+                "Registration \nNumber": "None",
+                "Trustee/Beneficiary": "None"
+            }
+        ],
+        "person": {
+            "slug": "bernice-swarts"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "NA",
+                "Source": "NA"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "DP Mabe Consulting",
+                "Type of Business \nActivity": "Rental",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "NA",
+                "Name of State Entity": "NA",
+                "Period of Contract": "NA",
+                "Value of \nContract": "NA"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "DP Mabe Consulting",
+                "Type of Business Activity": "Rental"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NA",
+                "Source": "NA",
+                "Value": "NA"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Small Holding",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Magliesburg"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Local Government"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": "None"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Multichoice",
+                "Nature": "Private",
+                "Nominal Value": "",
+                "Number of Shares": "Phuthoma"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "NA",
+                "Extent": "NA",
+                "Source of Sponsorship": "NA"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "NA",
+                "Sponsor": "NA"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "NA",
+                "Name of Trust": "NA",
+                "Registration \nNumber": "NA",
+                "Trustee/Beneficiary": "NA"
+            }
+        ],
+        "person": {
+            "slug": "bertha-peace-mabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "None",
                 "Source": "None"
             }
@@ -6406,6 +9420,266 @@
         ],
         "person": {
             "slug": "bheki-mathews-hadebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Nil",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "Nil",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Mnyezane Fuel",
+                "Type of Business Activity": "Fuel"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Nil",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential",
+                "Extent of the Property": "1400 square metres",
+                "Location \u2013 Area": "Vrede, Free State"
+            },
+            {
+                "Description of Property": "Residential",
+                "Extent of the Property": "400 square metres",
+                "Location \u2013 Area": "Vrede, Free State"
+            },
+            {
+                "Description of Property": "Residential",
+                "Extent of the Property": "1808 square metres",
+                "Location \u2013 Area": "Standerton, \nMpumalanga"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Nil",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "Nil",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "bhekiziswe-abram-radebe"
         },
         "release": {
             "date": "2020-12-31",
@@ -7552,6 +10826,256 @@
         "entries": [
             {
                 "Description of Benefit": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE",
+                "Extent of the Property": "3 BEDROOMS",
+                "Location \u2013 Area": "COLESBERG"
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": ""
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "THIRD PARTY",
+                "Name of Trust": "ASIPHE MBINQO TRUST",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": "ASIPHE"
+            }
+        ],
+        "person": {
+            "slug": "bongiwe-pricilla-mbinqo-gigaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
                 "Source": "NIL"
             }
         ],
@@ -7831,6 +11355,256 @@
         ],
         "person": {
             "slug": "boyce-makhosonke-maneli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Khomanani Agricultural Cooperatives",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House \nFarm",
+                "Extent of the Property": "6 Bedrooms \n10 Hectares",
+                "Location \u2013 Area": "Dzingidzingi Village \nMageva Village"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "brenda-tirhani-mathevula"
         },
         "release": {
             "date": "2020-12-31",
@@ -11093,6 +14867,471 @@
     },
     {
         "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Not applicable",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "Not applicable",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Not applicable",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Not applicable",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House & Flat \nRegisterred in Trust",
+                "Extent of the Property": "House 530 square metres on 1100 square plot \nFlat 200 square metres",
+                "Location \u2013 Area": "Malmesbury"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Not applicable",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "Family Home & Flat",
+                "Name of Trust": "Hunsinger Family Trust",
+                "Registration \nNumber": "IT1437/2006",
+                "Trustee/Beneficiary": "Trustee/Beneficiary"
+            }
+        ],
+        "person": {
+            "slug": "christian-hans-heinrich-hunsinger"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit N/L": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/L",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/L",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "PLOUGHING RESIDENTAL",
+                "Extent of the Property": "4 MORGAN \n2 ACRES",
+                "Location \u2013 Area": "ETHALANENI IN \nNKANDLA"
+            },
+            {
+                "Description of Property": "Source",
+                "Location \u2013 Area": "Public/Private"
+            },
+            {
+                "Description of Property": "OLD MUTUAL WEALTH",
+                "Location \u2013 Area": "PUBLIC"
+            },
+            {
+                "Description of Property": "Period of Contract",
+                "Extent of the Property": "Value of \nContract",
+                "Location \u2013 Area": "Name of State Entity"
+            },
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "PHUTHUMANATHI",
+                "Nature": "ORDINARY",
+                "Nominal Value": "R110-00 each",
+                "Number of Shares": "2000"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            },
+            {
+                "Description of \nAssistance/Sponsorship": "Value",
+                "Extent": "Source",
+                "Source of Sponsorship": "Description"
+            },
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "STUDY FEES FOR LEARNER \nAPPLICANTS",
+                "Name of Trust": "KING SOLOMON BURSARY FUND TRUST",
+                "Registration \nNumber": "T580/2018/(D)",
+                "Trustee/Beneficiary": "I AM TRUSTEE"
+            }
+        ],
+        "person": {
+            "slug": "christian-themba-msimang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "DIRECTORSHIP AND PARTNERSHIPS",
             "sort_order": 3
         },
@@ -12617,6 +16856,256 @@
         ],
         "person": {
             "slug": "creecy-barbara"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "n/a",
+                "Source": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "n/a",
+                "Type of Business \nActivity": "n/a",
+                "Value of any Benefits \nderived": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "n/a",
+                "Name of State Entity": "n/a",
+                "Period of Contract": "n/a",
+                "Value of \nContract": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "n/a",
+                "Type of Business Activity": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "n/a",
+                "Source": "n/a",
+                "Value": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "3 bedroom, 3 bathrooms (The Cove)",
+                "Location \u2013 Area": "Langebaan, \nWes Kaap"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "n/.a",
+                "Source": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "n/a",
+                "Type of Business": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "n/a",
+                "Nature": "n/a",
+                "Nominal Value": "n/a",
+                "Number of Shares": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "n/a",
+                "Extent": "n/a",
+                "Source of Sponsorship": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "n/a",
+                "Sponsor": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "n/a",
+                "Name of Trust": "n/a",
+                "Registration \nNumber": "n/a",
+                "Trustee/Beneficiary": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "d-van-der-walt"
         },
         "release": {
             "date": "2020-12-31",
@@ -14954,6 +19443,293 @@
         },
         "entries": [
             {
+                "Description of Benefit": "Voyager Miles",
+                "Source": "SAA"
+            },
+            {
+                "Description of Benefit": "Executive Club Miles",
+                "Source": "BA"
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential",
+                "Extent of the Property": "1 500 sq m",
+                "Location \u2013 Area": "Morningside, Durban"
+            },
+            {
+                "Description of Property": "Residential",
+                "Extent of the Property": "500 sq m",
+                "Location \u2013 Area": "Umhlanga, Durban"
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "AngloAmerican",
+                "Nature": "Ordinary",
+                "Nominal Value": "R180 000",
+                "Number of Shares": "384"
+            },
+            {
+                "Name of Company": "Malbak",
+                "Nature": "Ordinary",
+                "Nominal Value": "R 70 000",
+                "Number of Shares": "7370"
+            },
+            {
+                "Name of Company": "HighPine",
+                "Nature": "Ordinary",
+                "Nominal Value": "R160 000",
+                "Number of Shares": "998"
+            },
+            {
+                "Name of Company": "BoardSyndicteTwo",
+                "Nature": "Ordinary",
+                "Nominal Value": "R 28 000",
+                "Number of Shares": "30"
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": ""
+            },
+            {
+                "Description of Journey": "Multi-party oversight delegation",
+                "Sponsor": "SA Israel Foundation"
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "dianne-kohler-barnard"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "N/A"
             }
@@ -16547,7 +21323,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16568,7 +21344,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16590,7 +21366,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16610,7 +21386,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16631,7 +21407,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16662,7 +21438,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16682,7 +21458,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16702,7 +21478,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16724,7 +21500,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16745,7 +21521,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16765,7 +21541,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -16787,7 +21563,7 @@
             }
         ],
         "person": {
-            "slug": "dorries-eunice-dlakude"
+            "slug": "dorris-eunice-dlakude"
         },
         "release": {
             "date": "2020-12-31",
@@ -17312,6 +22088,506 @@
         ],
         "person": {
             "slug": "duma-moses-nkosi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "dumisani-fannie-mthenjane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House and Car",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/a",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "edward-zoyisile-njadu"
         },
         "release": {
             "date": "2020-12-31",
@@ -19078,6 +24354,204 @@
         ],
         "person": {
             "slug": "emma-louise-powell"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Nothing to Dislose",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "emmanuel-nkosinathi-mthethwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Nothing to Diclose",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "emmanuel-nkosinathi-mthethwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "1. Aljazira Extra Virgin Oil (100ml)",
+                "Source": "Ambassador of the Republic of Tunisia",
+                "Value": "R90.00"
+            },
+            {
+                "Description": "Books \n- African Odysser \nby Tutus Malofo \n- Siya Kolisi: \nAgainst all odds \nby Jeremy Daniel",
+                "Source": "Dr Stravos Nicolaou",
+                "Value": "R450.00"
+            },
+            {
+                "Description": "Tsunagu Blended \nWhisky (750ml) SUS \nGallery",
+                "Source": "Embassy of Japan",
+                "Value": "R1287.00"
+            },
+            {
+                "Description": "Memoirs of an \nAfrican Diplomat- A \ndream fulfilled",
+                "Source": "Thandi Lujabe-Rankoe",
+                "Value": "R150.00"
+            },
+            {
+                "Description": "Items \n- Africa for smart \nKids: Let\u2019s talk \nabout \u201cThe \nPrincess of Africa\u201d \nby Beatrice \nAchaleka \n- A Motherhood \nTour \u2013 A Journey \nof African Women \nwith Yvonne \nChaka-Chaka \n(DVD)",
+                "Source": "Yvonne Chaka-Chaka",
+                "Value": "R435.00"
+            },
+            {
+                "Description": "2X Dijo Books",
+                "Source": "Lesego Masenya",
+                "Value": "R690.00"
+            },
+            {
+                "Description": "Photo Album with \nPhoto\u2019s",
+                "Source": "Burkino Faso Embassy",
+                "Value": "N/A"
+            },
+            {
+                "Description": "Sappi 2020 Calendar",
+                "Source": "Sappi Limited",
+                "Value": "N/A"
+            },
+            {
+                "Description": "Puma Escaper Sixe9 \nSneakers",
+                "Source": "South African Football Association",
+                "Value": "R586.00"
+            },
+            {
+                "Description": "Items \n- Crawford Styled \nRed Pringle Shirt \n- ANC Cap",
+                "Source": "",
+                "Value": "R1129.00"
+            }
+        ],
+        "person": {
+            "slug": "emmanuel-nkosinathi-mthethwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1180 sqm",
+                "Location \u2013 Area": "Dainfern"
+            },
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Kwa Mbonambi"
+            },
+            {
+                "Description of Property": "Land",
+                "Extent of the Property": "302 000sqm",
+                "Location \u2013 Area": "Klaarwater"
+            }
+        ],
+        "person": {
+            "slug": "emmanuel-nkosinathi-mthethwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Government",
+                "Source": "Political Office Bearer"
+            }
+        ],
+        "person": {
+            "slug": "emmanuel-nkosinathi-mthethwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Mevana",
+                "Nature": "Beneficiary",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            },
+            {
+                "Name of Company": "Batho Batho",
+                "Nature": "Beneficiary",
+                "Nominal Value": "3 321 396",
+                "Number of Shares": "N/A"
+            },
+            {
+                "Name of Company": "Sasol Inzalo Public LTD",
+                "Nature": "Insignificant",
+                "Nominal Value": "N/A",
+                "Number of Shares": "Share Holding"
+            },
+            {
+                "Name of Company": "MTN Group LTD",
+                "Nature": "Insignificant",
+                "Nominal Value": "N/A",
+                "Number of Shares": "Share Holding"
+            }
+        ],
+        "person": {
+            "slug": "emmanuel-nkosinathi-mthethwa"
         },
         "release": {
             "date": "2020-12-31",
@@ -22863,6 +28337,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "NA",
+                "Source": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NA",
+                "Type of Business \nActivity": "NA",
+                "Value of any Benefits \nderived": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "NA",
+                "Name of State Entity": "NA",
+                "Period of Contract": "NA",
+                "Value of \nContract": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Hillwick Pty Ltd",
+                "Type of Business Activity": "Property"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NA",
+                "Source": "NA",
+                "Value": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Primary residence - house",
+                "Extent of the Property": "130 m2",
+                "Location \u2013 Area": "Edgemead, Cape Town"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "NA",
+                "Source": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NA",
+                "Type of Business": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Standard Bank",
+                "Nature": "TFSA",
+                "Nominal Value": "R250 000",
+                "Number of Shares": "Various"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "NA",
+                "Extent": "NA",
+                "Source of Sponsorship": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "NA",
+                "Sponsor": "NA"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "None",
+                "Name of Trust": "The Hill-Lewis Trust",
+                "Registration \nNumber": "IT2799/2012",
+                "Trustee/Beneficiary": "Trustee"
+            }
+        ],
+        "person": {
+            "slug": "geordin-gwyn-hill-lewis"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "-"
             }
@@ -23385,6 +29109,256 @@
         ],
         "person": {
             "slug": "gerhardus-willem-koornhof"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "none"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "none",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "none",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "none",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "none",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Primary residence \nFlat/apartment \nFlat/Apartment \n2 Motor vehicles \u2013 2012 Volvo C30 and 2019 Fiat 500",
+                "Extent of the Property": "4 bedroom property \n2 bedrooms \n1 bedroom",
+                "Location \u2013 Area": "Parktown North 2193 Cape Town CBD \nCape Town CBD \nJHB"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Parliamentary pension scheme \nAllan Gray"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "none",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Springtrade cc \nMentisfactum (pty) Ltd",
+                "Nature": "Ord \nOrd",
+                "Nominal Value": "Par \nNo current \nincome/assets",
+                "Number of Shares": "25% \n100%"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "none"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "none"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "No current assets/ income",
+                "Name of Trust": "Luiza cachalia Trust",
+                "Registration \nNumber": "IT889/85",
+                "Trustee/Beneficiary": "Luiza \nCachalia/Chiara \nCachalia"
+            }
+        ],
+        "person": {
+            "slug": "ghaleb-cachalia"
         },
         "release": {
             "date": "2020-12-31",
@@ -28072,6 +34046,69 @@
     },
     {
         "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "3 bedrooms house \n4 bedrooms house \n5 bedrooms house",
+                "Extent of the Property": "3 bedrooms House, \n4 bedrooms house \n5 bedrooms house",
+                "Location \u2013 Area": "Glenwood , Durban \nGlenwood, Durban \nGlenwood, Durban"
+            }
+        ],
+        "person": {
+            "slug": "hlengiwe-octavia-hlophe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "GEPF"
+            }
+        ],
+        "person": {
+            "slug": "hlengiwe-octavia-hlophe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "MTN",
+                "Nature": "",
+                "Nominal Value": "R5000",
+                "Number of Shares": "01"
+            }
+        ],
+        "person": {
+            "slug": "hlengiwe-octavia-hlophe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "BENEFITS",
             "sort_order": 7
         },
@@ -31093,6 +37130,282 @@
         },
         "entries": [
             {
+                "Description of Benefit": "Free Parking",
+                "Source": "Eikestad Mall Stellenbosch"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Millstream Property \nSolutions (pty) ltd",
+                "Type of Business \nActivity": "Property Service Agency",
+                "Value of any Benefits \nderived": "Use of company car"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "I\u2019m a Director of Key Capital (pty) Ltd, a \n20% co-owner of \nEikestad Mall, \nStellenbosch. The Mall is managed by the \n80% owner, Attacq listed fund. The \nmunicipality leases 484m2 of office space, total Mall area is \n48025m2, so 1% of the total lettable area.",
+                "Name of State Entity": "Municipality of \nStellenbosch",
+                "Period of Contract": "Initial Lease: \n1 Oct 2016 to 30 Sep 2019 \nLease Renewal: \n1 Oct 2019 to 30 Sep 2024",
+                "Value of \nContract": "The renewal total value to Eikestad Mall over 5 years is R 7 170 159,69."
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Director Key Capital Property Holdings (pty) ltd",
+                "Type of Business Activity": "Property Investment"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Director Millstream Capital (pty) ltd",
+                "Type of Business Activity": "Property Investment"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "2020 calendar",
+                "Source": "Japanese Consulate",
+                "Value": "R200"
+            },
+            {
+                "Description": "Moleskin Notebook",
+                "Source": "Taiwan Consulate",
+                "Value": "R300"
+            },
+            {
+                "Description": "Lunch at Maria\u2019s Greek restaurant",
+                "Source": "Taiwan Consulate",
+                "Value": "R200"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential House",
+                "Extent of the Property": "991 square meters",
+                "Location \u2013 Area": "Strand, Cape Town"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Parliament Pension Fund"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Millstream Property Solutions (pty) ltd",
+                "Nature": "Company",
+                "Nominal Value": "R 100 000.00",
+                "Number of Shares": "100"
+            },
+            {
+                "Name of Company": "JN de Villiers Trust",
+                "Nature": "Trust",
+                "Nominal Value": "R 2 000 000.00",
+                "Number of Shares": "50% Beneficiary"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "No benefits received in 2020",
+                "Name of Trust": "JN de Villiers Trust",
+                "Registration \nNumber": "IT451/2006",
+                "Trustee/Beneficiary": "Trustee & \nBeneficiary"
+            },
+            {
+                "Details of all \nbenefits derived": "No benefits received in 2020",
+                "Name of Trust": "Trustee Key Capital Trust",
+                "Registration \nNumber": "IT 1302/2005",
+                "Trustee/Beneficiary": "Trustee"
+            }
+        ],
+        "person": {
+            "slug": "jan-naude-de-villiers"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "None"
             }
@@ -31579,6 +37892,266 @@
         ],
         "person": {
             "slug": "jane-seboletswe-mananiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N\\A",
+                "Source": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N\\A",
+                "Value of any Benefits \nderived": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N\\A",
+                "Name of State Entity": "N\\A",
+                "Period of Contract": "N\\A",
+                "Value of \nContract": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N\\A",
+                "Type of Business Activity": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N\\A",
+                "Source": "N\\A",
+                "Value": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "6637 BASBOOM STREET, OCHARDS ,Extension 33",
+                "Extent of the Property": "5 BEDROOMED HOUSE",
+                "Location \u2013 Area": "PRETORIA NORTH"
+            },
+            {
+                "Description of Property": "17 MOPANE STREET, FLORA PARK",
+                "Extent of the Property": "3 BEDROOMED HOUSE",
+                "Location \u2013 Area": "POLOKWANE"
+            },
+            {
+                "Description of Property": "SHILUVANE",
+                "Extent of the Property": "2 BEDROOMED HOUSE",
+                "Location \u2013 Area": "TZANEEN LOCATION"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N\\A",
+                "Source": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N\\A",
+                "Nature": "N/A",
+                "Nominal Value": "N\\A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N\\A",
+                "Extent": "N\\A",
+                "Source of Sponsorship": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N\\A",
+                "Sponsor": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "jerome-joseph-maake"
         },
         "release": {
             "date": "2020-12-31",
@@ -36615,6 +43188,531 @@
         },
         "entries": [
             {
+                "Description of Benefit": "-",
+                "Source": "NO BENEFITS FROM ANYONE"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "-",
+                "Value of any Benefits \nderived": "-"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "-",
+                "Name of State Entity": "-",
+                "Period of Contract": "NONE",
+                "Value of \nContract": "-"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "-",
+                "Value": "-"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE",
+                "Extent of the Property": "4 BEDROOM",
+                "Location \u2013 Area": "WHITE RIVER \nMPUMALANGA"
+            },
+            {
+                "Description of Property": "BUILDING",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "WHITE RIVER \nMPUMALANGA"
+            },
+            {
+                "Description of Property": "FLAT",
+                "Extent of the Property": "2 BEDROOM",
+                "Location \u2013 Area": "NELSPRUIT \nMPUMALANGA"
+            },
+            {
+                "Description of Property": "HOUSE",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "NELSPRUIT \nMPUMALANGA"
+            },
+            {
+                "Description of Property": "STAND",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "NELSPRUIT \nMPUMALANGA"
+            },
+            {
+                "Description of Property": "3 STANDS",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "WHITE RIVER \nMPUMALANGA"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "GOVERNMENT"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "-"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "-",
+                "Nature": "-",
+                "Nominal Value": "-",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "-",
+                "Extent": "-",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "-",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "-",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "-",
+                "Trustee/Beneficiary": "-"
+            }
+        ],
+        "person": {
+            "slug": "kwati-candith-mashego-dlamini"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "NA",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE \nHOUSE",
+                "Extent of the Property": "Four (4) Bedroom House) \nTwo (2) Bedroom House)",
+                "Location \u2013 Area": "LONEHILL \u2013 JHB \nTHABANE WEST \nRUSTENBURG"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "GOVERNMENT \nPRIVATE \nPRIVATE",
+                "Source": "SPECIAL PENSION \nLIBERTY LIFE \nOASIS"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "MTN",
+                "Nature": "ZAKHELE BEE",
+                "Nominal Value": "R200 000",
+                "Number of Shares": "ONE"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "l-d-zulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "N/A"
             }
@@ -36851,6 +43949,756 @@
         ],
         "person": {
             "slug": "laetitia-heloise-arries"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Mangaung Holdings",
+                "Type of Business Activity": "General - Dormant"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Book and Tea",
+                "Source": "Chinese Embassy",
+                "Value": "Unknown"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "None",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorshi p": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "None",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "lawrence-edward-mc-donald"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Work Pension, Activists Pension"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Activists special pension",
+                "Type of Business": "Special pension"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Akhona,discovery,old mutual investment",
+                "Nature": "Investments",
+                "Nominal Value": "",
+                "Number of Shares": "2"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lc-bebee"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/a"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/a",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/a",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/a",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/a",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Freestanding house",
+                "Extent of the Property": "570 square meters",
+                "Location \u2013 Area": "Cape Town"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/a"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Princeton Innovations for Successful Societies",
+                "Type of Business": "Research"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/a"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/a"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/a"
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/a",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "leon-amos-schreiber"
         },
         "release": {
             "date": "2020-12-31",
@@ -37604,6 +45452,261 @@
         },
         "entries": [
             {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1104sqm",
+                "Location \u2013 Area": "Door de Kraal, Bellville"
+            },
+            {
+                "Description of Property": "Vacant land",
+                "Extent of the Property": "1757sqm",
+                "Location \u2013 Area": "Rooi Els"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "PZ van der Merwe Family Trust",
+                "Nature": "Family Trust",
+                "Nominal Value": "Minimal",
+                "Number of Shares": "33%"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "liezl-linda-van-der-merwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "None"
             }
@@ -37858,6 +45961,256 @@
         ],
         "person": {
             "slug": "lindiwe-nonceba-sisulu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential \nResidential",
+                "Extent of the Property": "640 square metres \n930 square metres",
+                "Location \u2013 Area": "Kokstad \nDurban"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "lindiwe-ntombikayise-mjobo"
         },
         "release": {
             "date": "2020-12-31",
@@ -38608,6 +46961,256 @@
         ],
         "person": {
             "slug": "lulama-maxwell-ntshayisa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Em\u2019ganwini Kraal",
+                "Type of Business Activity": "Events and Functions Venue"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Farm \nHouse",
+                "Extent of the Property": "19ha \n4 Bedroom House",
+                "Location \u2013 Area": "Mzinti \u2013 Nkomazi \nMzinti"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": "None"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "None",
+                "Nature": "None",
+                "Nominal Value": "None",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "None",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "lusizo-sharon-makhubela-mashele"
         },
         "release": {
             "date": "2020-12-31",
@@ -39922,6 +48525,256 @@
             }
         ],
         "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOMESTEAD/HOUSE",
+                "Extent of the Property": "3 Bedrooms house",
+                "Location \u2013 Area": "ULUNDI - KZN"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "GEPF",
+                "Source": "RETIREMENT PENSION"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "magdalena-duduzile-hlengwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
             "slug": "maidi-dorothy-mabiletsa"
         },
         "release": {
@@ -40153,6 +49006,261 @@
         ],
         "person": {
             "slug": "maidi-dorothy-mabiletsa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "RESIDENTIAL",
+                "Extent of the Property": "STAND ALONE, \nR350 000.00",
+                "Location \u2013 Area": "BENDOR, \nPOLOKWANE"
+            },
+            {
+                "Description of Property": "RESIDENTIAL",
+                "Extent of the Property": "ESTATE \nR 3 400 000.00",
+                "Location \u2013 Area": "PEACANWOOD, \nHAARTEBEESPOORT"
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "GOVERNMENT EMPLOYEE PENSION FUND"
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "maite-emily-nkoana-mashabane"
         },
         "release": {
             "date": "2020-12-31",
@@ -40427,6 +49535,256 @@
         ],
         "person": {
             "slug": "makgabo-reginah-mhaule"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "NONE",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "NONE",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Bertha Gxowa Foundation",
+                "Type of Business Activity": "Philanthropic"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "NONE",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "WATERKLOOF RIDGE \nWATER/KLF RIDGE \n(daughters\u2019) \nARCADIA \nPYRAMID \nATTERIDGEVILLE(Mothers\u2019)",
+                "Extent of the Property": "2000 Square meters \n1500 Square meters \n300 Square meters \n12,5 Hectors \n500 Square meters",
+                "Location \u2013 Area": "TSHWANE \nTSHWANE \nTSHWANE \nTSHWANE \nTSHWANE"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private",
+                "Source": "Momentum"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "MTN",
+                "Nature": "ASONKE",
+                "Nominal Value": "R200",
+                "Number of Shares": "774"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "NONE",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "NONE",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "makgathatso-charlotte-chana-pilane-majake"
         },
         "release": {
             "date": "2020-12-31",
@@ -40932,6 +50290,256 @@
         ],
         "person": {
             "slug": "makoti-sibongile-khawula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/a",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "GEPF 2873"
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "malesane-priscilla-themba"
         },
         "release": {
             "date": "2020-12-31",
@@ -42214,6 +51822,152 @@
     },
     {
         "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Keldoron Properties 8",
+                "Type of Business Activity": "Unremunerated"
+            }
+        ],
+        "person": {
+            "slug": "mangosuthu-gatsha-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Compound - the extent of which has not been \ndetermined",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Mahlabathini, KZN"
+            },
+            {
+                "Description of Property": "Land",
+                "Extent of the Property": "2998 sq.m",
+                "Location \u2013 Area": "Ubombo"
+            },
+            {
+                "Description of Property": "Undeveloped land",
+                "Extent of the Property": "1517 sq.m",
+                "Location \u2013 Area": "Kwasishwilli"
+            }
+        ],
+        "person": {
+            "slug": "mangosuthu-gatsha-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "KwaZulu Legislature Office Bearers Pension"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Sanlam"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Momentum"
+            }
+        ],
+        "person": {
+            "slug": "mangosuthu-gatsha-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Old Mutual",
+                "Nature": "Investor F",
+                "Nominal Value": "+/- R71000",
+                "Number of Shares": "1648.22"
+            },
+            {
+                "Name of Company": "Sanlam",
+                "Nature": "Unit Trust",
+                "Nominal Value": "+/- R21000",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Kuphelile Investments",
+                "Nature": "Ordinary",
+                "Nominal Value": "R1 each",
+                "Number of Shares": "51"
+            },
+            {
+                "Name of Company": "Glen Invest",
+                "Nature": "Ordinary",
+                "Nominal Value": "+/- R101250",
+                "Number of Shares": "37000"
+            }
+        ],
+        "person": {
+            "slug": "mangosuthu-gatsha-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "(Nothing to \nDisclose)",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            },
+            {
+                "Name of Trust": "CEBEKHULU",
+                "Registration \nNumber": "RUSSEL NSIKAYEZWE",
+                "Trustee/Beneficiary": "IFP \u2013 INKATHA \nFREEDOM PARTY"
+            }
+        ],
+        "person": {
+            "slug": "mangosuthu-gatsha-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "BENEFITS",
             "sort_order": 7
         },
@@ -42460,6 +52214,261 @@
         ],
         "person": {
             "slug": "manketsi-mamoabi-emily-tlhape"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "Free Standing House 496m2",
+                "Location \u2013 Area": "Johannesburg"
+            },
+            {
+                "Description of Property": "Apartment",
+                "Extent of the Property": "Sectional Title 47m2",
+                "Location \u2013 Area": "Cape Town"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "manuel-simao-franca-de-freitas"
         },
         "release": {
             "date": "2020-12-31",
@@ -45083,6 +55092,565 @@
         ],
         "person": {
             "slug": "matshidiso-melina-gomba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "None",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "None",
+                "Value of any Benefits \nderived": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "None",
+                "Name of State Entity": "None",
+                "Period of Contract": "None",
+                "Value of \nContract": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Flowers",
+                "Source": "Departmental Events",
+                "Value": "+_ R500"
+            },
+            {
+                "Description": "Diaries",
+                "Source": "Various Sources",
+                "Value": "+_ R400"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "R2,9 M",
+                "Location \u2013 Area": "261/2 Hofmeyer Rd, Midrand"
+            },
+            {
+                "Description of Property": "2 Huts",
+                "Extent of the Property": "R99 000",
+                "Location \u2013 Area": "Modjadjiskloof"
+            },
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "R690 600",
+                "Location \u2013 Area": "Duiwelskloof"
+            },
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "R670 000",
+                "Location \u2013 Area": "Duiwelskloof"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "None",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "None",
+                "Nature": "None",
+                "Nominal Value": "None",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "None",
+                "Extent": "None",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "None",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "None",
+                "Name of Trust": "None",
+                "Registration \nNumber": "None",
+                "Trustee/Beneficiary": "None"
+            }
+        ],
+        "person": {
+            "slug": "matsie-angelina-motshekga"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Trans York Services",
+                "Type of Business Activity": "De-registered"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Mega Works Trading Enterprise 187",
+                "Type of Business Activity": "Program/Project Management"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "SARGB Holdings",
+                "Type of Business Activity": "Resigned"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "North West Star- NTI \nAtteridgeville Bus Services",
+                "Type of Business Activity": "Resigned"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Resigned"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Western Breeze Trading 110",
+                "Type of Business Activity": "Projects/Program and property"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Mosa Projects and Investments",
+                "Type of Business Activity": "General enterprise/Projects"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "3381 Tshegofatso Street",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Tlhabane (joint)"
+            },
+            {
+                "Description of Property": "3393 Tshegofatso Street",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Tlhabane (joint)"
+            },
+            {
+                "Description of Property": "Portion 8 Erf 1658",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Safari Ext 8 (joint)"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public (no pension received yet)",
+                "Source": "Municipal Councillors Pension Fund"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "MTN",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "Yebo Yethu"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "None/ Inactive",
+                "Name of Trust": "Tlhabane Taxi \nOwners",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            },
+            {
+                "Details of all \nbenefits derived": "None \nNone \nNone",
+                "Name of Trust": "Matthew Wolmarans Family Trust",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": "Lillian Wolmarans Limath Wolmarans Mathli Wolmarans"
+            }
+        ],
+        "person": {
+            "slug": "matthews-johannes-wolmarans"
         },
         "release": {
             "date": "2020-12-31",
@@ -48102,6 +58670,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "NA"
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NA",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NA",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "NA",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NA",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1700m2",
+                "Location \u2013 Area": "Boksburg"
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private \nPublic",
+                "Source": "Liberty Life \nParliament"
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NA",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "NA"
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NA"
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "Study tour on liberal values to Germany",
+                "Sponsor": "Fredrick Nauman Foundation"
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NA",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "michele-odette-clarke"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "NONE",
                 "Source": "NONE"
             }
@@ -48857,6 +59675,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "NAMAHADI RESTAURANT",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "42B NAMAHADI, \nWITSIESHOEK"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mishack-makosini-chabangu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "Nothing to declare"
             }
@@ -49362,6 +60430,256 @@
             }
         ],
         "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "FORTE FM",
+                "Type of Business \nActivity": "RADIO STATION",
+                "Value of any Benefits \nderived": "VARIES"
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "mlindi-advent-nhanha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
             "slug": "mm-ntuli"
         },
         "release": {
@@ -49593,6 +60911,520 @@
         ],
         "person": {
             "slug": "mm-ntuli"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "CBC Funerals",
+                "Type of Business Activity": "(Not yet generating income)"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmabatho-olive-mokause"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Mashala Projects",
+                "Type of Business Activity": "Project Management (de-registration outstanding from CIPC for more than 5yrs)"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Ketsona Building Construction",
+                "Type of Business Activity": "Construction (de-registration outstanding from CIPC for more than 5yrs)"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "DATE \nSOURCE \nDESCRIPTION \nVALUE \n18 \nSouth \nBirds of Prey \nR862.00 \n/02/2019 \nAfrican \nWorking \nReserve Bank \nGroup coin, \nMandela R50 \nuncirculated \ncoin , \nMandela \nNote book \nand Pen \n21/02/2019 Mr David \nYibeixiang \nR1500.00 \nZhong \nTea, \nDiptyque \nParis \nPerfume \n10/04/2019 Mr Thabo \nWinnie \nR10 \nMsimang \nMandela \n000.00 \npicture \nFrame \n24 \nNational \nBox of books Unknown \n/04/2019 \nInstitute for \nthe \nHumanities \nand Social \nSciences \n15/05/2019 Mr Chris \nSpa at \nR2875.00 \nAckeer \nMarion \nANC \nVoucher \nSecretary \nGenerals \nOffice \n06/06/2019 Russian \nCape Vintage \nR260.00 \nAmbassador \nReserve 2016 \n06/06/2019 Mr David \nTwo boxes of \nR300.00 \nZhong \nChinese Tea",
+                "Source": "",
+                "Value": ""
+            },
+            {
+                "Description": "07/06/2019 Black \nBooks R400.00 \nManagement \nForum \n13/06/2019 TBCSA \nMetalic \nR6000.00 \nwelcome Gift \nGiraffe \nStatue",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential \u2013 House",
+                "Extent of the Property": "3 bedroom house",
+                "Location \u2013 Area": "Soweto"
+            },
+            {
+                "Description of Property": "Residential \u2013 House",
+                "Extent of the Property": "5 bedroom house",
+                "Location \u2013 Area": "Midrand"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "mmamoloko-tryphosa-kubayi"
         },
         "release": {
             "date": "2020-12-31",
@@ -51499,6 +63331,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "EPPF",
+                "Type of Business Activity": "Pension Fund"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "Mortaged",
+                "Location \u2013 Area": "Dawn Park, Boksburg"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private",
+                "Source": "Aspire Stanlib"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NOne",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "None",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "mohatla-alfred-tseki"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -52981,6 +65063,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Moneimang enterprise",
+                "Type of Business Activity": "General"
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Immovable property",
+                "Extent of the Property": "1190,00 \n1190,00",
+                "Location \u2013 Area": "Kimberly \nkuruman"
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Political office beares pension"
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Moneimang",
+                "Nature": "General",
+                "Nominal Value": "",
+                "Number of Shares": "100%"
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": ""
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "Chairperson of Audit and finance and \nboard sitting \nallowance",
+                "Name of Trust": "John Taolo \nGaetsewe \ndevelopmental",
+                "Registration \nNumber": "IT2728/2002",
+                "Trustee/Beneficiary": "Trustee"
+            }
+        ],
+        "person": {
+            "slug": "mosimanegare-kenneth-mmoiemang"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -53536,6 +65868,615 @@
         },
         "entries": [
             {
+                "Description of Benefit": "Not Applicable",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "Not Applicable",
+                "Value of any Benefits \nderived": "Not Applicable"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "Not Applicable",
+                "Name of State Entity": "Not Applicable",
+                "Period of Contract": "None",
+                "Value of \nContract": "Not Applicable"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": "Not Applicable"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Travel Suit Carrier \nPringle Jersey",
+                "Source": "Office staff Birthday Gift",
+                "Value": "R3000"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Free Standing Residential Property",
+                "Extent of the Property": "RSA 2091 Portion \n00000820-00000.Winchester Hills \n1361 square meters",
+                "Location \u2013 Area": "388 Devereaux Avenue Winchester Hills \nJohannesburg South"
+            },
+            {
+                "Description of Property": "",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Government Pension Fund"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Not Applicable",
+                "Type of Business": "Not Applicable"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Old Mutual",
+                "Nature": "PLC Shares",
+                "Nominal Value": "11 pence per \nvalue",
+                "Number of Shares": "300"
+            },
+            {
+                "Name of Company": "Old Mutual",
+                "Nature": "Ordinary Shares",
+                "Nominal Value": "10 pence par \nvalue",
+                "Number of Shares": "262"
+            },
+            {
+                "Name of Company": "Sanlam Insurance Policy",
+                "Nature": "Ordinary Shares",
+                "Nominal Value": "130 cents per \nshare",
+                "Number of Shares": "297"
+            },
+            {
+                "Name of Company": "Liberty Life Insurance Policy: RA STANLIB MONEY MARKET FUND",
+                "Nature": "They do not \nstipulate",
+                "Nominal Value": "10.53 per cent",
+                "Number of Shares": "54156.0773"
+            },
+            {
+                "Name of Company": "Liberty Life Insurance Policy: RA GLOBAL MANAGED",
+                "Nature": "They do not \nstipulate",
+                "Nominal Value": "12.46 per cent",
+                "Number of Shares": "68568.5592"
+            },
+            {
+                "Name of Company": "Liberty Life Insurance Policy: RA LS \nVARIABLE",
+                "Nature": "They do not \nstipulate",
+                "Nominal Value": "14.19 per cent",
+                "Number of Shares": "54438.293"
+            },
+            {
+                "Name of Company": "Liberty Life Insurance Policy: RA LS \nPROPERTY",
+                "Nature": "They do not \nstipulate",
+                "Nominal Value": "62.82 per cent",
+                "Number of Shares": "18104.1546"
+            },
+            {
+                "Name of Company": "Investment: Yebo \nYethu",
+                "Nature": "Ordinary Shares",
+                "Nominal Value": "0.74 cents per \nshare",
+                "Number of Shares": "100"
+            },
+            {
+                "Name of Company": "Pili Tau Investment",
+                "Nature": "FNB Investment: Ashburton Money Market Fund & Coronation",
+                "Nominal Value": "R2,761,947",
+                "Number of Shares": "100%"
+            },
+            {
+                "Name of Company": "Investment: Antfarm (Pty) Ltd",
+                "Nature": "Ordinary Shares",
+                "Nominal Value": "R250 000",
+                "Number of Shares": "25.5%"
+            },
+            {
+                "Name of Company": "Investment: Sunset Bay (Pty) Ltd: SAWIMI",
+                "Nature": "Ordinary Shares",
+                "Nominal Value": "R3.06 per share",
+                "Number of Shares": "22803"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "Not Applicable",
+                "Extent": "Not Applicable",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "Not Applicable",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "Not Applicable",
+                "Name of Trust": "None",
+                "Registration \nNumber": "Not Applicable",
+                "Trustee/Beneficiary": "Not Applicable"
+            }
+        ],
+        "person": {
+            "slug": "mpho-parks-franklyn-tau"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "OR TAMBO SCHOOL OF LEADERSHIP",
+                "Type of Business Activity": "ANC POLITICAL SCHOOL"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "SA Taxi Association",
+                "Source": "R500",
+                "Value": "Notepad and pen"
+            },
+            {
+                "Description": "ABSIP",
+                "Source": "R500",
+                "Value": "Notepad and pen"
+            },
+            {
+                "Description": "SA Taxi Association",
+                "Source": "R500",
+                "Value": "Notepad and pen"
+            },
+            {
+                "Description": "Nedbank / Oldmutual",
+                "Source": "R5000",
+                "Value": "Financial donation \n(Donate to charity)"
+            },
+            {
+                "Description": "Kuul",
+                "Source": "R1100",
+                "Value": "1X Tie, 1 X Socks, 1X perfume tester"
+            },
+            {
+                "Description": "ABSIP",
+                "Source": "R109",
+                "Value": "1X bottle of 750ml wine (Kanonkop Kadette Cape Blend 2017)"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "LAND",
+                "Extent of the Property": "1500 square metres",
+                "Location \u2013 Area": "LIMPOPO"
+            },
+            {
+                "Description of Property": "Sectional Title",
+                "Extent of the Property": "74 square metres",
+                "Location \u2013 Area": "GAUTENG"
+            },
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1031 square metres",
+                "Location \u2013 Area": "GAUTENG"
+            },
+            {
+                "Description of Property": "LAND",
+                "Extent of the Property": "7512 square metres",
+                "Location \u2013 Area": "GAUTENG"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PRIVATE",
+                "Source": "EMPLOYMENT X11"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "Travel to Germany with other Opposition leaders in SA Parliament in relation to political work",
+                "Sponsor": "German Government"
+            },
+            {
+                "Description of Journey": "Political Education Study Tour Travel to Germany",
+                "Sponsor": "FES"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "none",
+                "Name of Trust": "TOPISA",
+                "Registration \nNumber": "NR:IT1359/2015",
+                "Trustee/Beneficiary": "Trustee"
+            }
+        ],
+        "person": {
+            "slug": "mr-masondo-david"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -54022,6 +66963,756 @@
         ],
         "person": {
             "slug": "ms-mahlo-nhlagonwe-patricia"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House \nHouse \nHouse",
+                "Extent of the Property": "3 Bedrooms \n 3 Bedrooms \n 3 Bedrooms",
+                "Location \u2013 Area": "Mookgophong \nPolokwane \nGroblersdal"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-maluleke-boitumelo-joyce"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "Permanent",
+                "Location \u2013 Area": "Thohoyandou"
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Foster Care grant"
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "ms-ramadwa-matodzi-mirriam"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "PGM Property Limited \nSAWIMI",
+                "Type of Business Activity": "Property business \nMining"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1337.0000 50 SQM",
+                "Location \u2013 Area": "Polokwane"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Yebo Yethu (RF) \nLimited",
+                "Nature": "Ordinary",
+                "Nominal Value": "6000",
+                "Number of Shares": "100"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "ms-semenya-machwene-rosinah"
         },
         "release": {
             "date": "2020-12-31",
@@ -55858,6 +69549,287 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Hair tinting and styling",
+                "Source": "Palladium",
+                "Value": "R1500 per \nmonth"
+            },
+            {
+                "Description": "Leather bound diary",
+                "Source": "Ambassador of Argentina",
+                "Value": "R500"
+            },
+            {
+                "Description": "Description",
+                "Source": "Source",
+                "Value": "Value"
+            },
+            {
+                "Description": "Candy gift hamper",
+                "Source": "Mayor of Tacoma",
+                "Value": "R500"
+            },
+            {
+                "Description": "Wall hanging calendar",
+                "Source": "Embassy of Japan",
+                "Value": "R500"
+            },
+            {
+                "Description": "Wall hanging art",
+                "Source": "Govt. of Tibet in exile",
+                "Value": "R1000"
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            },
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "natasha-wendy-anita-michael"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "Accelerated life cover (as the beneficiary of my late mothers policy)",
                 "Source": "Hollard"
             },
@@ -56098,6 +70070,256 @@
         ],
         "person": {
             "slug": "nazley-khan-sharif"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House \nCar",
+                "Extent of the Property": "6 Rooms + 2 Garages \nKia",
+                "Location \u2013 Area": "Hazeldene, Philippi"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nceba-ephraim-hinana"
         },
         "release": {
             "date": "2020-12-31",
@@ -57635,6 +71857,405 @@
     },
     {
         "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "NOTHING TO \nDISCLOSE",
+                "Name of State Entity": "NOTHING TO \nDISCLOSE",
+                "Period of Contract": "NOTHING TO \nDISCLOSE",
+                "Value of \nContract": "NOTHING TO \nDISCLOSE"
+            }
+        ],
+        "person": {
+            "slug": "nkosazana-dlamini-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "ZIMBALI SUITES",
+                "Extent of the Property": "2 BEDROOM APARTMENT",
+                "Location \u2013 Area": "KWAZULU NATAL"
+            },
+            {
+                "Description of Property": "RURAL HOUSE (PARENT) PLOT 92 - ZIMBALI",
+                "Extent of the Property": "HOME \u2013 6 Bedroom house \nHOME \u2013 6 Bedroom house",
+                "Location \u2013 Area": "KWAZULU NATAL \nKWAZULU NATAL"
+            }
+        ],
+        "person": {
+            "slug": "nkosazana-dlamini-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "ALEXANDER FORBES & DEPARTMENT OF FINANCE GEPF"
+            },
+            {
+                "Public/Private": "PRIVATE",
+                "Source": "GLACIER"
+            },
+            {
+                "Public/Private": "PRIVATE",
+                "Source": "PENSION (1994-2012)"
+            }
+        ],
+        "person": {
+            "slug": "nkosazana-dlamini-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of \nCompany": "SASOL",
+                "Nature": "SHARES",
+                "Nominal Value": "R4358.55 (R88.95 per share)",
+                "Number of Shares": "49"
+            },
+            {
+                "Name of \nCompany": "SANLAM",
+                "Nature": "SHARES",
+                "Nominal Value": "R34667.36 \n(R47.62 per share)",
+                "Number of Shares": "728"
+            },
+            {
+                "Name of \nCompany": "SASOL INZALO",
+                "Nature": "SHARES",
+                "Nominal Value": "LOCKED UNTIL 2028",
+                "Number of Shares": "233"
+            }
+        ],
+        "person": {
+            "slug": "nkosazana-dlamini-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "NOTHING TO \nDICLOSE",
+                "Name of Trust": "THE NKOSAZANA ZUMA FAMILY \nTRUST",
+                "Registration \nNumber": "IT1405/1997/PMB",
+                "Trustee/Beneficiary": "1.Nkosazana Clarice Dlamini Zuma \n2. Gugulethu Zuma \n3.Jennifer Jane \nPartridge \n4. Johan Georg \nSmith"
+            }
+        ],
+        "person": {
+            "slug": "nkosazana-dlamini-zuma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Bheki Mlangeni Foundation - Trustee",
+                "Type of Business Activity": "Non Profitable Organisation"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "9 Roomed",
+                "Location \u2013 Area": "136 11th Avenue \nKensington \nJHB, 2094"
+            },
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "5 Rooms \n3 Bedrooms",
+                "Location \u2013 Area": "687 Protea North \nSoweto, JHB"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "P.O.B.P.F"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Momentum"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Marriot"
+            },
+            {
+                "Public/Private": "Public",
+                "Source": "Military Veterans"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "SANLAM Limited",
+                "Nature": "Shares",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nkosiyakhe-amos-masondo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "BENEFITS",
             "sort_order": 7
         },
@@ -57886,6 +72507,256 @@
         ],
         "person": {
             "slug": "nobuhle-pamela-nkabane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "NIL"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "NIL"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "3 BEDROOM HOUSE",
+                "Extent of the Property": "654 sqm",
+                "Location \u2013 Area": "KEMPTON PARK"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "NIL"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "NIL",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nocawe-noncedo-mafu"
         },
         "release": {
             "date": "2020-12-31",
@@ -59789,6 +74660,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "None",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "None",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "nomathemba-hendrietta-maseko-jele"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -60848,6 +75969,256 @@
         "entries": [
             {
                 "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Book and Chinese Tea",
+                "Source": "Chinese Embassy",
+                "Value": "Unknown"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "18 Fourie Str , 3Bedroom House",
+                "Extent of the Property": "Residential",
+                "Location \u2013 Area": "Sasolburg"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Whiphold",
+                "Nature": "Mining",
+                "Nominal Value": "R1000",
+                "Number of Shares": "Stock fell Purchase"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorshi p": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "nomsa-josephina-kubheka"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
                 "Source": ""
             }
         ],
@@ -61603,6 +76974,577 @@
         "entries": [
             {
                 "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Edgebay",
+                "Type of Business Activity": ""
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Dyambo",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Clayport",
+                "Source": "April 2019",
+                "Value": "Cuba"
+            },
+            {
+                "Description": "2x Wooden Chopping board",
+                "Source": "April 2019",
+                "Value": "UNISA"
+            },
+            {
+                "Description": "Mandela Book of 100 Years of Madiba",
+                "Source": "April 2019",
+                "Value": "Parliament"
+            },
+            {
+                "Description": "The Plague",
+                "Source": "April 2019",
+                "Value": "Rand Easter \nShow"
+            },
+            {
+                "Description": "Bouquet of Flowers & Bottle of Vodka",
+                "Source": "3 May 2019",
+                "Value": "Russian \nEmbassy"
+            },
+            {
+                "Description": "",
+                "Source": "",
+                "Value": ""
+            },
+            {
+                "Description": "Key Holder, Lady\u2019s wallet & Leather File",
+                "Source": "18 May 2020",
+                "Value": "Oudsthoorn \nMilitary Base"
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "5x Bedroom House",
+                "Extent of the Property": "From: 2004",
+                "Location \u2013 Area": "Adolf Goertz Ave. Bruma"
+            },
+            {
+                "Description of Property": "3x Bedroom House",
+                "Extent of the Property": "From: 1994",
+                "Location \u2013 Area": "Cyrildine, Johannesburg"
+            },
+            {
+                "Description of Property": "3x Bedroom House",
+                "Extent of the Property": "From: 2013",
+                "Location \u2013 Area": "Guigney, East London"
+            },
+            {
+                "Description of Property": "3x Bedroom House",
+                "Extent of the Property": "From: 2011",
+                "Location \u2013 Area": "Protea Street, Cardock"
+            },
+            {
+                "Description of Property": "2x Bedroom House",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Lingelihle, Cradock, EC"
+            },
+            {
+                "Description of Property": "",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Special Pension",
+                "Source": "Government"
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Defence and Military Veterans",
+                "Type of Business": "Government Department"
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Old Mutual",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Sanlam",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "nosiviwe-noluthando-mapisa-nqakula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "None",
+                "Value of any Benefits \nderived": "None"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "NA",
+                "Name of State Entity": "NA",
+                "Period of Contract": "None",
+                "Value of \nContract": "NA"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": "None"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "Small house",
+                "Location \u2013 Area": "Port alfred"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private",
+                "Source": "Alexander Forbes"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "None",
+                "Nature": "None",
+                "Nominal Value": "None",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "NA",
+                "Name of Trust": "None",
+                "Registration \nNumber": "NA",
+                "Trustee/Beneficiary": "NA"
+            }
+        ],
+        "person": {
+            "slug": "noxolo-abraham-ntantiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
                 "Source": "NIL"
             }
         ],
@@ -61842,6 +77784,256 @@
         ],
         "person": {
             "slug": "noxolo-kiviet"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "BENTILOG PTY LTD",
+                "Type of Business Activity": "COMPANY DORMANT"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE",
+                "Extent of the Property": "3 BEDROOM",
+                "Location \u2013 Area": "MONTCLAIR/MPLAIN"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "nqabayomzi-lawrence-kwankwa"
         },
         "release": {
             "date": "2020-12-31",
@@ -63489,6 +79681,256 @@
     },
     {
         "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "NONE",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "TOWN HOUSE",
+                "Extent of the Property": "83M2",
+                "Location \u2013 Area": "CENTURION"
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NONE",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "oscar-masarona-mathafa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "CONTRACTS",
             "sort_order": 11
         },
@@ -64405,6 +80847,266 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Crystal Plate",
+                "Source": "US Embassy to South Africa",
+                "Value": "R2000"
+            },
+            {
+                "Description": "Glass Paperweight",
+                "Source": "US Embassy to South Africa",
+                "Value": "R608"
+            },
+            {
+                "Description": "Coffee Plunger & Coffee",
+                "Source": "Midvaal Municipality Mayor",
+                "Value": "R350"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1014 m2",
+                "Location \u2013 Area": "Pinelands Cape Town"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Public Office Bearers"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "None",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "patricia-de-lille"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "NA",
                 "Source": "NA"
             }
@@ -64910,6 +81612,256 @@
             }
         ],
         "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "2000 Facial Masks",
+                "Source": "MTN Foundation",
+                "Value": "R60 000"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "2x Sites House 69A \nMacacuma Village \nSterkspruit",
+                "Extent of the Property": "R 2.8 million",
+                "Location \u2013 Area": "Jamestown"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "Blankets and Grocery",
+                "Extent": "50 Blankets R180 x 50 100 Hampers R200 x 100",
+                "Source of Sponsorship": "Alimdaad Foundation"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pemmy-majodina"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
             "slug": "petrus-johannes-groenewald"
         },
         "release": {
@@ -65155,6 +82107,756 @@
         },
         "entries": [
             {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Domino Foods; St. Adens Logostics;P Electrical Fencing",
+                "Type of Business Activity": "All inactive and dormant"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "1500 square meters/ 03 Bedrooms",
+                "Location \u2013 Area": "Capital Park Pretoria"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N /A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "philippus-adriaan-van-staden"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phillip-matsapole-pogiso-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "03 HOUSES",
+                "Extent of the Property": "3 ROOMS \n4 ROOMS \n11 ROOMS",
+                "Location \u2013 Area": "MIDRAND \nGLEN OSTEN \nIVORY PARK"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "PRIVATE BUSINESS",
+                "Type of Business": "HOUSE RENTAL \nLIVESTOCK BUSINESS"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phindisile-pretty-xaba-ntshaba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "Nothing to declare"
             }
@@ -65349,6 +83051,256 @@
         ],
         "person": {
             "slug": "phiwaba-madokwe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House and Small holding",
+                "Extent of the Property": "2 bedroom/ 5ha",
+                "Location \u2013 Area": "Uitenhage"
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Buntiplex",
+                "Nature": "(PTY) LTD",
+                "Nominal Value": "4000",
+                "Number of Shares": "120"
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "phumeza-mpushe"
         },
         "release": {
             "date": "2020-12-31",
@@ -65613,6 +83565,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "Lounge Access and Platinum Travel Card",
+                "Source": "BA & SAA"
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "Study Tour on Disinformation",
+                "Sponsor": "Friedrich Naumann Foundation"
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "phumzile-thelma-van-damme"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "",
                 "Source": "N/A"
             }
@@ -65849,6 +84051,327 @@
         ],
         "person": {
             "slug": "pieter-mey"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "CPT Jazz Tickets",
+                "Source": "Kagiso Media, Multi Choice",
+                "Value": ""
+            },
+            {
+                "Description": "Cell phone",
+                "Source": "MTN , Huawei",
+                "Value": ""
+            },
+            {
+                "Description": "Spring walk",
+                "Source": "Jacaranda FM",
+                "Value": ""
+            },
+            {
+                "Description": "DSTV Delicious",
+                "Source": "Multi Choice",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "Standard bank",
+                "Location \u2013 Area": "Polokwane"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private",
+                "Source": "Old Mutual"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Sanlam"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Discovery"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Kagia Investment",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "The Dawn OHSE \nConsultants",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Matle",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Grant Kekana \nFoundation",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Pinky Kekana \nFoundation",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Maanda matla Energy and Petroleum",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Afri Tsimbi Steelworks",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "Tshireletse security and cleaning services",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            },
+            {
+                "Name of Company": "GRA IPE Holdings",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "pinky-sharon-kekana"
         },
         "release": {
             "date": "2020-12-31",
@@ -67216,6 +85739,506 @@
         ],
         "person": {
             "slug": "rachel-cecilia-adams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "WHIPHOLD",
+                "Registration \nNumber": "1987/002097/06",
+                "Trustee/Beneficiary": "RAESIBE MARTHA"
+            }
+        ],
+        "person": {
+            "slug": "raesibe-martha-moatshe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "1HOUSE \n2 HOUSE",
+                "Extent of the Property": "RESIDENTIAL \nRESIDENTIAL",
+                "Location \u2013 Area": "45 RICHMOND \nGARDENS DURBAN \n10 RIBBON ROAD \nNEWLANDS DURBAN"
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "regina-mina-mpontseng-lesoma"
         },
         "release": {
             "date": "2020-12-31",
@@ -69849,6 +88872,277 @@
         "entries": [
             {
                 "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Vista GRT",
+                "Type of Business Activity": "NPO (Deregistration process)"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Zelpy 1097",
+                "Type of Business Activity": "Final Deregistration"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Spyline Tracing Agency",
+                "Type of Business Activity": "Final Deregistration"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "Entrepreneurial Business Services",
+                "Type of Business Activity": "Final Deregistration"
+            },
+            {
+                "Directorship/Partnership in any Corporate Body": "The Owl House Foundation",
+                "Type of Business Activity": "NPO"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "625m2",
+                "Location \u2013 Area": "Graaff-Reinet"
+            },
+            {
+                "Description of Property": "House (belongs to ex \nhusband as per Divorce agreement but remains in both names)",
+                "Extent of the Property": "10 000m2",
+                "Location \u2013 Area": "Aberdeen"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "Nil"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "None",
+                "Name of Trust": "The Giant Flag \nTrust",
+                "Registration \nNumber": "IT 61/2012",
+                "Trustee/Beneficiary": "Trustee"
+            }
+        ],
+        "person": {
+            "slug": "samantha-jane-graham"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
                 "Source": "NONE"
             }
         ],
@@ -70070,6 +89364,256 @@
         ],
         "person": {
             "slug": "sampson-phathakge-makwetla"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "samukelo-christopher-sibisi"
         },
         "release": {
             "date": "2020-12-31",
@@ -71343,6 +90887,330 @@
         "entries": [
             {
                 "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "DIRECTORSHIP": "Director & \nShareholder",
+                "NAME": "ENDINITE",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Investment",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director & \nShareholder",
+                "NAME": "REPUBLICOM",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Investment",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director & \nShareholder",
+                "NAME": "TSUTSUMA \nCORPORATIO N",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Investment",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director & \nShareholder",
+                "NAME": "IKGODISO \nMINERALS",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Mining",
+                "VALUE": "Unknown"
+            },
+            {
+                "DIRECTORSHIP": "Shareholder",
+                "NAME": "SIHAYO \nTECHNOLOG Y HOLDINGS",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Investment",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director & \nShareholder",
+                "NAME": "African Spirit Trading 435",
+                "OWNERSHI P": "Private \nCompany",
+                "TYPE \nOF \nBUSINE \nSS": "Investment",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director",
+                "NAME": "ODFJELL \nTERMINALS SA",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Logistics",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director",
+                "NAME": "MAKANA \nCOMPONENT S HOLDINGS",
+                "OWNERSHI P": "PRIVATE \nCOMPANY",
+                "TYPE \nOF \nBUSINE \nSS": "Investment",
+                "VALUE": "Nil"
+            },
+            {
+                "DIRECTORSHIP": "Director \nDirector & \nShareholder \nDirector & \nShareholder \nDirector & \nShareholder \nDirector \nShareholder",
+                "NAME": "SIKULU \nPIPING \nSUPPLY \nAfrican Spirit Trading 465 \nTsotsoma \nLogistic \nTsotsoma \nEnergy \nConsulting \nSihayo \nTechnology \nHoldings",
+                "OWNERSHI P": "PRIVATE \nCOMPANY \nPrivate \ncompany \nPrivate \nCompany \nPrivate \nCompany \nPrivate \nCompany",
+                "TYPE \nOF \nBUSINE \nSS": "Piping \nInvestment s \nLogistics \nEnergy \nManufactu ring \nInvestment Investment",
+                "VALUE": "Nil \nNil \nNil \nNil \nNil \nNil \nNil"
+            },
+            {
+                "DIRECTORSHIP": "Director & \nShareholder \nDirector \nShareholder & \nDirector \nDirector \nDirector \nDirector \nDirector",
+                "NAME": "Sihayo \nInvestment \nChaldean \nTrading 57 \nOdjfell \nTerminal SA \nMevana \ninvestments \nLTSM Supply Chain Solution \nMakana \nstationery & \nsupplies \nMakana \nenergy \nconsortium",
+                "OWNERSHI P": "Private \nCompany \nPrivate \nCompany \nPrivate \nCompany \nPrivate \nCompany \nPrivate \nCompany \nPrivate \nCompany \nPrivate \nCompany \nPrivate \ncompany \nPrivate \nCompany",
+                "TYPE \nOF \nBUSINE \nSS": "Logistic \nInvestment s \nConsulting Consulting \nStationery Energy",
+                "VALUE": "Nil \nNil \nNil \nNil \nNil \nNil \nNil"
+            },
+            {
+                "NAME": "Directorship/Partnership in any Corporate Body",
+                "OWNERSHI P": "Type of Business Activity"
+            },
+            {
+                "NAME": "",
+                "OWNERSHI P": ""
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "50% of House \n50% of House \n100% of House",
+                "Extent of the Property": "\u00b1 2000m\u00b2 \n\u00b12000m\u00b2 \n\u00b18000m\u00b2",
+                "Location \u2013 Area": "33 Northleigh Crescent, River Club, \nJohannesburg \n68 Sir Arthur Road, \nMorningside, Durban \n3 Amy Wilson Street, Hilton, Pietermaritzburg"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "R5719 per month \nR2728 per month",
+                "Source": "Public Pension \nPrivate Investment"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "See Directorship & Partnerships below"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "Mboneni Trust \nPhakathwayo Trust",
+                "Registration \nNumber": "IT/359/2000 \nIT/5690/04",
+                "Trustee/Beneficiary": "Trustee & \nBeneficiary \nTrustee"
+            }
+        ],
+        "person": {
+            "slug": "sfiso-norbert-buthelezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
                 "Source": "N/A"
             }
         ],
@@ -71618,6 +91486,256 @@
             }
         ],
         "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "None",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "50% of House",
+                "Extent of the Property": "550sq erf",
+                "Location \u2013 Area": "Upington"
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "None",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "sharome-renay-van-schalkwyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "None"
+            }
+        ],
+        "person": {
             "slug": "shaun-nigel-august"
         },
         "release": {
@@ -71849,6 +91967,67 @@
         ],
         "person": {
             "slug": "shaun-nigel-august"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "1. Residential",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Nqabara"
+            },
+            {
+                "Description of Property": "2. Residential",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Johannesburg"
+            },
+            {
+                "Description of Property": "3. Residential",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "East London"
+            },
+            {
+                "Description of Property": "4. Residential",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Dutywa"
+            },
+            {
+                "Description of Property": "5. Plot",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Stutterheim"
+            }
+        ],
+        "person": {
+            "slug": "sheilla-tembalam-xego-sovita"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "GEPF"
+            }
+        ],
+        "person": {
+            "slug": "sheilla-tembalam-xego-sovita"
         },
         "release": {
             "date": "2020-12-31",
@@ -72390,6 +92569,261 @@
         },
         "entries": [
             {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "14268 JD Khumalo \nstreet"
+            },
+            {
+                "Description of Property": "",
+                "Extent of the Property": "",
+                "Location \u2013 Area": "Orkney"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-macdonald-kula"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "House",
                 "Source": "Inheritance"
             }
@@ -72626,6 +93060,256 @@
         ],
         "person": {
             "slug": "sibusiso-nigel-gumede"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "NONE",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House no.37",
+                "Extent of the Property": "987m",
+                "Location \u2013 Area": "Shefield Cove"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Old Mutual",
+                "Nature": "Ordinary Shares",
+                "Nominal Value": "",
+                "Number of Shares": "300"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NONE",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "sibusiso-welcome-mdabe"
         },
         "release": {
             "date": "2020-12-31",
@@ -73416,6 +94100,256 @@
     },
     {
         "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "N/A",
+                "Location \u2013 Area": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "sinawo-tambo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "LAND AND PROPERTY",
             "sort_order": 9
         },
@@ -73937,6 +94871,256 @@
     },
     {
         "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "NONE",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "NONE",
+                "Value of any Benefits \nderived": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "NONE",
+                "Name of State Entity": "NONE",
+                "Period of Contract": "NONE",
+                "Value of \nContract": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "AUTSHUMATU",
+                "Type of Business Activity": "INVESTMENTS WORTH 9%"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "ONE SHEEP",
+                "Source": "INKOSI ZONDI \n(PIETERMARITZBURG)",
+                "Value": "R2000"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE \nHOUSE \nFLATS (2) \nKHURUMANI COMPLEX",
+                "Extent of the Property": "OWNER, 5 BEDROOMS AND 2 BEDROOM GRANNY FLAT \nOWNER, 3 BEDROOMS AND 2 BEDROOM GRANNY FLAT \nINVESTOR, SHOPPING COMPLEX",
+                "Location \u2013 Area": "45 BAINES ROAD, \nGLENMORE \n233 FREMONTIA \nSTREET, LYNWOOD \nUMBILO ROAD, \nDURBAN \nINVESTMENT MADE IN 2008"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "UMKONTO WESIZWE \u2013 EX POLITICAL PRISONERS"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "SIHAYO \nINVESTMENTS",
+                "Nature": "ORDINARY",
+                "Nominal Value": "R2M",
+                "Number of Shares": "10%"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "NONE",
+                "Extent": "NONE",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "NONE",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "FROM FLATS OF THE FAMILY AND HOUSE IN \nPRETORIA \nBENFITS THOSE WHOSE \nOBJECTIVES ARE SUPPORTED BY \nBBT",
+                "Name of Trust": "SM DHLOMO \nTRUST \nBATHO BATHO \nTRUST (BBT)",
+                "Registration \nNumber": "IT437/97",
+                "Trustee/Beneficiary": "CHILDREN OF \nMINE \nANYBODY OR \nORGANIZATION THAT BENEFITS FROM THE \nOBJECTIVE OF \nTHE TRUST"
+            }
+        ],
+        "person": {
+            "slug": "sm-dhlomo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "GIFTS AND HOSPITALITY",
             "sort_order": 6
         },
@@ -74220,6 +95404,410 @@
         ],
         "person": {
             "slug": "sophie-suzan-thembekwayo"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NOTHING",
+                "Type of Business \nActivity": "TO DISCLOSE",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "TO",
+                "Period of Contract": "NOTHING",
+                "Value of \nContract": "DISCLOSE"
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "PASTELLAR EVENTS (PTY) LTD",
+                "Type of Business Activity": "EVENTS MANAGEMENT"
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "LAND",
+                "Extent of the Property": "60x90sqm",
+                "Location \u2013 Area": "MARHAMBENI \nLOCATION- MTHATHA"
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "GOVERNMENT"
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "MTN",
+                "Nature": "PRIVATE",
+                "Nominal Value": "",
+                "Number of Shares": "817"
+            },
+            {
+                "Name of Company": "VODACOM",
+                "Nature": "PRIVATE",
+                "Nominal Value": "",
+                "Number of Shares": "100"
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NOTHING",
+                "Registration \nNumber": "TO",
+                "Trustee/Beneficiary": "DISCLOSE"
+            }
+        ],
+        "person": {
+            "slug": "stella-tembisa-ndabeni-abrahams"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "none"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "none",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Blaizepoint Trading",
+                "Type of Business Activity": "Trading"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "3 Bedroom House \nresidential",
+                "Extent of the Property": "3 bedroom House",
+                "Location \u2013 Area": "Potchefstroom"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Parliament - member"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "None"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "none"
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "none",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "stephanus-franszouis-du-toit"
         },
         "release": {
             "date": "2020-12-31",
@@ -75512,6 +97100,268 @@
         },
         "entries": [
             {
+                "Description of Benefit": "Allan Gray",
+                "Source": "Tax-free savings investment"
+            },
+            {
+                "Description of Benefit": "Allan Gray",
+                "Source": "Flexible unit trust"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Not applicable",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "Not applicable",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Not applicable",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Chocolates",
+                "Source": "Friend",
+                "Value": "R120"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "The house has 5 bedrooms, 5 bathrooms, kitchen, dining room, lounge, double garage and garden",
+                "Location \u2013 Area": "Mafikeng"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Parliament",
+                "Source": "Alexander Forbes"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Allan Gray"
+            },
+            {
+                "Public/Private": "Private",
+                "Source": "Momentum"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Not applicable",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "Not applicable"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "Not applicable",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tebogo-modise"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -75753,6 +97603,256 @@
         ],
         "person": {
             "slug": "teliswa-mgweba"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential House",
+                "Extent of the Property": "03 rooms",
+                "Location \u2013 Area": "Durban \u2013 Verelum"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "terence-skhumbuzo-mpanza"
         },
         "release": {
             "date": "2020-12-31",
@@ -76257,6 +98357,256 @@
         ],
         "person": {
             "slug": "thabo-nelson-mmutle"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Maprata Property Development",
+                "Type of Business Activity": "Property development"
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential property",
+                "Extent of the Property": "3 bedroom house",
+                "Location \u2013 Area": "Dawn park"
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N\\A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N\\A"
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "thamsanqa-bhekokwakhe-mabhena"
         },
         "release": {
             "date": "2020-12-31",
@@ -77243,6 +99593,368 @@
         },
         "entries": [
             {
+                "Description of Benefit": "None",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "None",
+                "Value of any Benefits \nderived": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "None",
+                "Name of State Entity": "None",
+                "Period of Contract": "None",
+                "Value of \nContract": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": "None."
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "None",
+                "Value": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "6 rooms*",
+                "Location \u2013 Area": "Free state, Welkom"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "none",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Amampevu, Basakha trading",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "Not active"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "None",
+                "Extent": "None",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "None",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "None",
+                "Name of Trust": "None",
+                "Registration \nNumber": "None",
+                "Trustee/Beneficiary": "None"
+            }
+        ],
+        "person": {
+            "slug": "thanduxolo-david-khalipha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Farm \nHouse \nHouse",
+                "Extent of the Property": "+/-423ha \n10 rooms and 3 garages 5 rooms and 1garage",
+                "Location \u2013 Area": "Vryheid 4 Hartebees Street \nEMpangeni B134 \nNgwelezane Township"
+            }
+        ],
+        "person": {
+            "slug": "thembeka-vuyisile-buyisile-mchunu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Councillors Pension Fund",
+                "Source": "Councillors Pension"
+            }
+        ],
+        "person": {
+            "slug": "thembeka-vuyisile-buyisile-mchunu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Evorich/Skyway",
+                "Nature": "Crypto Units",
+                "Nominal Value": "N/A",
+                "Number of Shares": "285 196"
+            }
+        ],
+        "person": {
+            "slug": "thembeka-vuyisile-buyisile-mchunu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "School uniform for \ndisadvantaged children",
+                "Extent": "Once off \nR30 000",
+                "Source of Sponsorship": "Mr Percy Govender"
+            }
+        ],
+        "person": {
+            "slug": "thembeka-vuyisile-buyisile-mchunu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "Cattle and sheep \nfarm Equipment",
+                "Name of Trust": "Nyawozekewu \nFamily Trust",
+                "Registration \nNumber": "IT: 1535/2007",
+                "Trustee/Beneficiary": "Trustee"
+            },
+            {
+                "Details of all \nbenefits derived": "None",
+                "Name of Trust": "Senzo and \nThembeka Mchunu Foundation",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": "Founder"
+            }
+        ],
+        "person": {
+            "slug": "thembeka-vuyisile-buyisile-mchunu"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "NONE"
             }
@@ -77782,6 +100494,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "N/A",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "thembinkosi-tevin-apleni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -78273,6 +101235,256 @@
         ],
         "person": {
             "slug": "thlologelo-malatji"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House \nLand",
+                "Extent of the Property": "3 Bedrooms, double Garage 800 square meters",
+                "Location \u2013 Area": "Morningside \u2013 Durban Doonside - Durban"
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "thokozani-makhosonke-langa"
         },
         "release": {
             "date": "2020-12-31",
@@ -79552,6 +102764,256 @@
     },
     {
         "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "None",
+                "Source": "None"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "None",
+                "Type of Business \nActivity": "None",
+                "Value of any Benefits \nderived": "Zero"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "None",
+                "Name of State Entity": "None",
+                "Period of Contract": "None",
+                "Value of \nContract": "Zero"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "None",
+                "Type of Business Activity": "None"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "None",
+                "Source": "None",
+                "Value": "Zero"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "House",
+                "Extent of the Property": "440 sqm \u2013 6 bedrooms",
+                "Location \u2013 Area": "Kimberley"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private",
+                "Source": "Old Mutual Wealth Retirement Income"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "None",
+                "Type of Business": "None"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Mtn Group Limited",
+                "Nature": "Shares",
+                "Nominal Value": "R5974",
+                "Number of Shares": "103"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "None",
+                "Extent": "None",
+                "Source of Sponsorship": "None"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "None",
+                "Sponsor": "None"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "Maintenance for \nminor children. \nDeceased Spouse .",
+                "Name of Trust": "Pettersson",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": "Terrence Daniel \nPettersson \nAustin Amos \nPettersson"
+            }
+        ],
+        "person": {
+            "slug": "tina-monica-joemat-pettersson"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
             "name": "CONTRACTS",
             "sort_order": 11
         },
@@ -79706,6 +103168,69 @@
         ],
         "person": {
             "slug": "tito-titus-mboweni"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Residential House",
+                "Extent of the Property": "4 bedroomed house",
+                "Location \u2013 Area": "Soshanguve, Pretoria"
+            }
+        ],
+        "person": {
+            "slug": "tlou-maggie"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Government pension"
+            }
+        ],
+        "person": {
+            "slug": "tlou-maggie"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "Nothing to close",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "tlou-maggie"
         },
         "release": {
             "date": "2020-12-31",
@@ -80470,6 +103995,506 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "NYATEMA PLANT HIRE",
+                "Type of Business Activity": "PLANT HIRE AND LOGISTICS"
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "ROAD AGENCY LIMPOPO"
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "tshitereke-baldwin-matibe"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "N/A",
+                "Source": "N/A",
+                "Value": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Site",
+                "Extent of the Property": "30 x 30",
+                "Location \u2013 Area": "Magojaneng village"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "N/A",
+                "Nature": "N/A",
+                "Nominal Value": "N/A",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "tshoganetso-mpho-adolphina-tongwane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -80706,6 +104731,256 @@
         ],
         "person": {
             "slug": "tyotyo-hubert-james"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "N/A",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Daisy Ubuntu Charity NGO",
+                "Type of Business Activity": "NGO \u2013 welfare ,disadvantage children and disabled people"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Framed plated eagle",
+                "Source": "DG David Lin , Taiwanese Embassy",
+                "Value": "unknown"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Farm",
+                "Extent of the Property": "8000ha",
+                "Location \u2013 Area": "Namaqualand"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Public",
+                "Source": "Parliament"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "Private (co-owner)",
+                "Type of Business": "Guest House"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "veronica-van-dyk"
         },
         "release": {
             "date": "2020-12-31",
@@ -81488,6 +105763,256 @@
         "entries": [
             {
                 "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "NONE",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "HOUSE",
+                "Extent of the Property": "FOUR BEDROOM",
+                "Location \u2013 Area": "SABIE"
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "GEPF"
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NONE",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "vuyisile-promise-malomane"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
                 "Source": "N/A"
             }
         ],
@@ -81973,6 +106498,256 @@
         ],
         "person": {
             "slug": "walter-tebogo-letsie"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NONE",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NONE",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "NONE",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NONE",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "SECONDARY RESIDENCE",
+                "Extent of the Property": "RESIDENTIAL 2BED ROOM 3 BEDROOM \nHUT",
+                "Location \u2013 Area": "SEBOKENG 1 \nHEILBRON 2 \nKWA MHLANGA"
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "PUBLIC",
+                "Source": "MILITARY VETERANS"
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NONE",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "",
+                "Nature": "",
+                "Nominal Value": "",
+                "Number of Shares": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NONE"
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NONE",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "washington-tseko-isaac-mafanya"
         },
         "release": {
             "date": "2020-12-31",
@@ -82742,6 +107517,256 @@
         },
         "entries": [
             {
+                "Description of Benefit": "",
+                "Source": "NA"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "NA",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "NA",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Afriana Tours \nSenators Wines",
+                "Type of Business Activity": "Tourism \nWine sales"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "NA",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Apartment",
+                "Extent of the Property": "2 Bedroom apartment",
+                "Location \u2013 Area": "Somerset West"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "NA"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "NA",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Afriana Tours \nSenators Wines",
+                "Nature": "Tourism \nSales",
+                "Nominal Value": "R 0 \nR 0",
+                "Number of Shares": "51% \n100 %"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "NA"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "NA"
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "NA",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "willem-frederik-faber"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
                 "Description of Benefit": "N/A",
                 "Source": "N/A"
             }
@@ -82978,6 +108003,256 @@
         ],
         "person": {
             "slug": "william-mothipa-madisha"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "Nothing to declare"
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "Nothing to declare",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "Nothing to declare",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "Nothing to declare",
+                "Type of Business Activity": ""
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Nothing to declare",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "Home (house)",
+                "Extent of the Property": "5 bedrooms, with one \nbedroom granny flat",
+                "Location \u2013 Area": "Retreat"
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Nothing to declare"
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "No",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Old Mutual",
+                "Nature": "Demutualisation",
+                "Nominal Value": "",
+                "Number of Shares": "Old Mutual"
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "Nothing to declare"
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "Flight: Board meeting, and accommodation",
+                "Sponsor": "Gallaudet University (Feb 2020)"
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "Nothing to declare",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "wilma-susan-newhoudt-druchen"
         },
         "release": {
             "date": "2020-12-31",
@@ -84357,6 +109632,256 @@
         ],
         "person": {
             "slug": "xolani-ngwezi"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "N/A",
+                "Source": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "N/A",
+                "Type of Business \nActivity": "N/A",
+                "Value of any Benefits \nderived": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "N/A",
+                "Name of State Entity": "N/A",
+                "Period of Contract": "N/A",
+                "Value of \nContract": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "N/A",
+                "Type of Business Activity": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "Cash Deposits",
+                "Source": "From my Sister (Nobengazi)",
+                "Value": "R3880.31"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "2 Houses",
+                "Extent of the Property": "6 roomed house (Primary Resident) \nAnd 3 roomed house \nportioned \nhouse(Development in \nprogress of premises, not liveable at this stage.",
+                "Location \u2013 Area": "Blomanda \nArea,9323, Bfn. \nRodenbeck, \nPhase6,9301,Bfn"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "Private",
+                "Source": "Old Mutual"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "N/A",
+                "Type of Business": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "Agent \nIndustrial ltd. \nDistell Group, \nLtd. \nStefanutti \nStocks Ltd. \nCrowd1",
+                "Nature": "Easy Equities \nEasy Equities \nEasy Equities \nShare Investment scheme",
+                "Nominal Value": "149,33 \n54,81 \n9,31 \nR2000",
+                "Number of Shares": "26,6667 \n0,7457 \n34,4828 \nR2000 Only"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "N/A",
+                "Extent": "N/A",
+                "Source of Sponsorship": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "N/A",
+                "Sponsor": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "N/A",
+                "Name of Trust": "N/A",
+                "Registration \nNumber": "N/A",
+                "Trustee/Beneficiary": "N/A"
+            }
+        ],
+        "person": {
+            "slug": "xolisile-shinars-qayiso"
         },
         "release": {
             "date": "2020-12-31",
@@ -86730,6 +112255,256 @@
         ],
         "person": {
             "slug": "zwelini-lawrence-mkhize"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "BENEFITS",
+            "sort_order": 7
+        },
+        "entries": [
+            {
+                "Description of Benefit": "",
+                "Source": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONSULTANCIES OR RETAINERSHIPS",
+            "sort_order": 4
+        },
+        "entries": [
+            {
+                "Name of Organisation": "n/a",
+                "Type of Business \nActivity": "",
+                "Value of any Benefits \nderived": ""
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "CONTRACTS",
+            "sort_order": 11
+        },
+        "entries": [
+            {
+                "Details of Contract and Management \nthereof": "",
+                "Name of State Entity": "",
+                "Period of Contract": "n/a",
+                "Value of \nContract": ""
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "DIRECTORSHIP AND PARTNERSHIPS",
+            "sort_order": 3
+        },
+        "entries": [
+            {
+                "Directorship/Partnership in any Corporate Body": "MK Freight Systems",
+                "Type of Business Activity": "Air Cargo"
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "GIFTS AND HOSPITALITY",
+            "sort_order": 6
+        },
+        "entries": [
+            {
+                "Description": "n/a",
+                "Source": "",
+                "Value": ""
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "LAND AND PROPERTY",
+            "sort_order": 9
+        },
+        "entries": [
+            {
+                "Description of Property": "n/a",
+                "Extent of the Property": "",
+                "Location \u2013 Area": ""
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "PENSIONS",
+            "sort_order": 10
+        },
+        "entries": [
+            {
+                "Public/Private": "",
+                "Source": "Parliament"
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "REMUNERATED EMPLOYMENT OUTSIDE PARLIAMENT",
+            "sort_order": 2
+        },
+        "entries": [
+            {
+                "Name of Employer": "n/a",
+                "Type of Business": ""
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SHARES AND OTHER FINANCIAL INTERESTS",
+            "sort_order": 1
+        },
+        "entries": [
+            {
+                "Name of Company": "MK Freight Systems",
+                "Nature": "Ordinary",
+                "Nominal Value": "n/a",
+                "Number of Shares": "30"
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "SPONSORSHIPS",
+            "sort_order": 5
+        },
+        "entries": [
+            {
+                "Description of \nAssistance/Sponsorship": "",
+                "Extent": "",
+                "Source of Sponsorship": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRAVEL",
+            "sort_order": 8
+        },
+        "entries": [
+            {
+                "Description of Journey": "",
+                "Sponsor": "n/a"
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
+        },
+        "release": {
+            "date": "2020-12-31",
+            "name": "Parliament Register of Members' Interests 2020",
+            "source_url": "https://www.parliament.gov.za/storage/app/media/Register%20of%20Members%20Interests/2020_Members_Interests_Register_final_1.pdf"
+        }
+    },
+    {
+        "category": {
+            "name": "TRUSTS",
+            "sort_order": 12
+        },
+        "entries": [
+            {
+                "Details of all \nbenefits derived": "",
+                "Name of Trust": "n/a",
+                "Registration \nNumber": "",
+                "Trustee/Beneficiary": ""
+            }
+        ],
+        "person": {
+            "slug": "zwelivelile-mandlesizwe-dalibhunga-mandela"
         },
         "release": {
             "date": "2020-12-31",


### PR DESCRIPTION
The script failed to find the person from: {u'slug': u'dorries-eunice-dlakude'} when running on prod. The member's slug was changed to dorris-eunice-dlakude 

![Screenshot from 2021-12-01 08-16-20](https://user-images.githubusercontent.com/6994982/144182407-ece42e44-c42b-4ddf-b0ac-35cdb3c1e9ee.png)


Other members' names I had to match manually:

BOZZOLI (MARRIED NAME VAN ONSELEN) BELINDA BOZZOLI

![Screenshot from 2021-12-01 08-19-08](https://user-images.githubusercontent.com/6994982/144182422-ab8cac08-2d21-42a5-b8b7-f7f3d4ddf7da.png)
