### PR TITLE
Use PgBouncer to pool db connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     image: pombola
     depends_on:
       - db
+      - pgbouncer
       - elasticsearch
     volumes:
       - ./data:/app-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     command: bin/wait-for-deps.sh python manage.py runserver 0.0.0.0:8000
 
   db:
-    image: postgres-9.6-postgis-2.3
+    image: openup/postgres-9.6-postgis-2.3
     environment:
       - POSTGRES_USER=pombola
       - POSTGRES_PASSWORD=pombola

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./data:/app-data
       - .:/app
     environment:
-      - DATABASE_URL=postgresql://pombola:pombola@pgbouncer/pombola
+      - DATABASE_URL=postgresql://pombola:pombola@pgbouncer:6432/pombola
       - DATABASE_NAME=pombola
       - POMBOLA_DATADIR=/app-data
       - DJANGO_DEBUG=TRUE
@@ -29,8 +29,6 @@ services:
     command: bin/wait-for-deps.sh python manage.py runserver 0.0.0.0:8000
 
   db:
-    build:
-      context: docker/db
     image: postgres-9.6-postgis-2.3
     environment:
       - POSTGRES_USER=pombola
@@ -40,18 +38,15 @@ services:
       - db-data:/var/lib/postgresql/data
   
   pgbouncer:
-    build:
-      context: docker/pgbouncer
-    image: edoburu/pgbouncer
-    environment:
-       - DB_USER=pombola
-       - DB_PASSWORD=pombola
-       - DB_HOST=db
-       - DB_NAME=pombola
-       - POOL_MODE=transaction
-       - ADMIN_USERS=pombola
+    image: docker.io/bitnami/pgbouncer:1
     ports:
-      - "5432:5432"
+      - 6432:6432
+    environment:
+       - POSTGRESQL_PASSWORD=pombola
+       - POSTGRESQL_USERNAME=pombola
+       - POSTGRESQL_DATABASE=pombola
+       - POSTGRESQL_HOST=db
+       - PGBOUNCER_DATABASE=pombola
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - db-data:/var/lib/postgresql/data
   
   pgbouncer:
+    context: edoburu/pgbouncer
     image: edoburu/pgbouncer
     environment:
        - DB_USER=pombola

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       - db-data:/var/lib/postgresql/data
   
   pgbouncer:
-    context: edoburu/pgbouncer
+    build:
+      context: docker/pgbouncer
     image: edoburu/pgbouncer
     environment:
        - DB_USER=pombola

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
        - DB_HOST=db
        - DB_NAME=pombola
        - POOL_MODE=transaction
-       - ADMIN_USERS=postgres,dbuser
+       - ADMIN_USERS=pombola
     ports:
       - "5432:5432"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./data:/app-data
       - .:/app
     environment:
-      - DATABASE_URL=postgresql://pombola:pombola@db/pombola
+      - DATABASE_URL=postgresql://pombola:pombola@pgbouncer/pombola
       - DATABASE_NAME=pombola
       - POMBOLA_DATADIR=/app-data
       - DJANGO_DEBUG=TRUE
@@ -38,6 +38,20 @@ services:
       - POSTGRES_DB=pombola
     volumes:
       - db-data:/var/lib/postgresql/data
+  
+  pgbouncer:
+    image: edoburu/pgbouncer
+    environment:
+       - DB_USER=pombola
+       - DB_PASSWORD=pombola
+       - DB_HOST=db
+       - DB_NAME=pombola
+       - POOL_MODE=transaction
+       - ADMIN_USERS=postgres,dbuser
+    ports:
+      - "5432:5432"
+    depends_on:
+      - db
 
   elasticsearch:
     image: elasticsearch:1


### PR DESCRIPTION
With gunicorn gevent and conn_max_age of 300 we are more likely to run out of database connections. Added pgBouncer to pool the connections.

Previously;
Django (app) <-> Postgres (db)

Proposed;
Django (app) <-> PgBouncer (pgbouncer) <-> Postgres (db)