### PR TITLE
PMG-111: fix footer 

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -1176,6 +1176,7 @@ FOOTER
         -moz-column-gap: 20px;
         -webkit-column-count: 2;
         -webkit-column-gap: 20px;
+        display: block;
     }
 
     .contact-details {


### PR DESCRIPTION
Footer styles were over-ridden when we added bootstrap library. The site-footer div has a class named `nav` and bootstrap has a similar class hence some styling from bootstrap was applied to our site-footer.

Before:

![Screenshot from 2022-01-13 20-49-01](https://user-images.githubusercontent.com/6994982/149383789-b8ed0a83-6d7b-4ff5-b44f-bb4eb0b42ab5.png)

After fix:

![Screenshot from 2022-01-13 20-56-08](https://user-images.githubusercontent.com/6994982/149383828-eee3fbaf-b499-488d-8428-e575f22c2aec.png)

Desktop
![Screenshot from 2022-01-13 20-55-54](https://user-images.githubusercontent.com/6994982/149383831-4ba7c575-9269-4e69-b292-61e07367e6e9.png)
