### PR TITLE
Pmg 111 fix remove ghost social title

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -3767,6 +3767,7 @@ h2.mp-subheading {
     width: 100%;
     margin-top: 2em;
     padding-top: 1em;
+    padding-bottom: 3em;
     -webkit-flex-wrap: wrap;
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
@@ -3775,6 +3776,7 @@ h2.mp-subheading {
 
 .mp-socials__title {
     width: 100%;
+    margin-bottom: 0em;
 }
 .svg-icon {
     display: -webkit-box;

--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -47,85 +47,87 @@
 
 {% block socials %}
 {% if person.is_current_member_of_national_assembly %}
-<div class="mp-socials">
-  <p class="mp-socials__title">
-    {{ object.title }} {{ object.name }} on social media:
-  </p>
-  {% if twitter_contacts %}
-  {% for twitter in twitter_contacts %}
-  <a href="https://twitter.com/{{ twitter|cut:" @"|cut:" " }}" class="webf-button is--social is--twitter w-inline-block">
-    <div class="button-icon">
-      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
-          data-prefix="fab" data-icon="twitter" class="svg-inline--fa fa-twitter fa-w-16" role="img"
-          viewBox="0 0 512 512">
-          <path fill="currentColor"
-            d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z">
-          </path>
-        </svg></div>
-    </div>
-    <p>@{{ twitter|cut:"@"|cut:" " }}</p>
-  </a>
-  {% endfor %}
-  {% endif %}
+  {% if twitter_contacts or facebook_contacts or whoswhosa_contacts or youtube_contacts or linkedin_contacts%}
+    <div class="mp-socials">
+      <p class="mp-socials__title">
+        {{ object.title }} {{ object.name }} on social media:
+      </p>
+      {% if twitter_contacts %}
+      {% for twitter in twitter_contacts %}
+      <a href="https://twitter.com/{{ twitter|cut:" @"|cut:" " }}" class="webf-button is--social is--twitter w-inline-block">
+        <div class="button-icon">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
+              data-prefix="fab" data-icon="twitter" class="svg-inline--fa fa-twitter fa-w-16" role="img"
+              viewBox="0 0 512 512">
+              <path fill="currentColor"
+                d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z">
+              </path>
+            </svg></div>
+        </div>
+        <p>@{{ twitter|cut:"@"|cut:" " }}</p>
+      </a>
+      {% endfor %}
+      {% endif %}
 
-  {% if facebook_contacts %}
-  {% for facebook in facebook_contacts %}
-  <a href="{{ facebook }}" class="webf-button is--social is--facebook w-inline-block">
-    <div class="button-icon">
-      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
-          data-prefix="fab" data-icon="facebook-square" class="svg-inline--fa fa-facebook-square fa-w-14" role="img"
-          viewbox="0 0 448 512">
-          <path fill="currentColor"
-            d="M400 32H48A48 48 0 0 0 0 80v352a48 48 0 0 0 48 48h137.25V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.27c-30.81 0-40.42 19.12-40.42 38.73V256h68.78l-11 71.69h-57.78V480H400a48 48 0 0 0 48-48V80a48 48 0 0 0-48-48z">
-          </path>
-        </svg></div>
-    </div>
-    <p>Facebook</p>
-  </a>
-  {% endfor %}
-  {% endif %}
+      {% if facebook_contacts %}
+      {% for facebook in facebook_contacts %}
+      <a href="{{ facebook }}" class="webf-button is--social is--facebook w-inline-block">
+        <div class="button-icon">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
+              data-prefix="fab" data-icon="facebook-square" class="svg-inline--fa fa-facebook-square fa-w-14" role="img"
+              viewbox="0 0 448 512">
+              <path fill="currentColor"
+                d="M400 32H48A48 48 0 0 0 0 80v352a48 48 0 0 0 48 48h137.25V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.27c-30.81 0-40.42 19.12-40.42 38.73V256h68.78l-11 71.69h-57.78V480H400a48 48 0 0 0 48-48V80a48 48 0 0 0-48-48z">
+              </path>
+            </svg></div>
+        </div>
+        <p>Facebook</p>
+      </a>
+      {% endfor %}
+      {% endif %}
 
-  {% if whoswhosa_contacts %}
-  {% for whoswhosa in whoswhosa_contacts %}
-  <a href="{{ whoswhosa }}" class="webf-button is--social is--whoswho w-inline-block">
-    Who&rsquo;s Who
-  </a>
-  {% endfor %}
-  {% endif %}
+      {% if whoswhosa_contacts %}
+      {% for whoswhosa in whoswhosa_contacts %}
+      <a href="{{ whoswhosa }}" class="webf-button is--social is--whoswho w-inline-block">
+        Who&rsquo;s Who
+      </a>
+      {% endfor %}
+      {% endif %}
 
-  {% if youtube_contacts %}
-  {% for youtube in youtube_contacts %}
-  <a href="{{ youtube }}" class="webf-button is--social is--youtube w-inline-block">
-    <div class="button-icon">
-      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
-          data-prefix="fab" data-icon="youtube" class="svg-inline--fa fa-youtube fa-w-18" role="img"
-          viewbox="0 0 576 512">
-          <path fill="currentColor"
-            d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z">
-          </path>
-        </svg></div>
+      {% if youtube_contacts %}
+      {% for youtube in youtube_contacts %}
+      <a href="{{ youtube }}" class="webf-button is--social is--youtube w-inline-block">
+        <div class="button-icon">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
+              data-prefix="fab" data-icon="youtube" class="svg-inline--fa fa-youtube fa-w-18" role="img"
+              viewbox="0 0 576 512">
+              <path fill="currentColor"
+                d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z">
+              </path>
+            </svg></div>
+        </div>
+        <p>Youtube</p>
+      </a>
+      {% endfor %}
+      {% endif %}
+      {% if linkedin_contacts %}
+      {% for linkedin in linkedin_contacts %}
+      <a href="{{ linkedin }}" class="webf-button is--social is--linkedin w-inline-block">
+        <div class="button-icon">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
+              data-prefix="fab" data-icon="linkedin" class="svg-inline--fa fa-linkedin fa-w-14" role="img"
+              viewbox="0 0 448 512">
+              <path fill="currentColor"
+                d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z">
+              </path>
+            </svg></div>
+        </div>
+        <p>LinkedIn</p>
+      </a>
+      {% endfor %}
+      {% endif %}
     </div>
-    <p>Youtube</p>
-  </a>
-  {% endfor %}
   {% endif %}
-  {% if linkedin_contacts %}
-  {% for linkedin in linkedin_contacts %}
-  <a href="{{ linkedin }}" class="webf-button is--social is--linkedin w-inline-block">
-    <div class="button-icon">
-      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"
-          data-prefix="fab" data-icon="linkedin" class="svg-inline--fa fa-linkedin fa-w-14" role="img"
-          viewbox="0 0 448 512">
-          <path fill="currentColor"
-            d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z">
-          </path>
-        </svg></div>
-    </div>
-    <p>LinkedIn</p>
-  </a>
-  {% endfor %}
-  {% endif %}
-</div>
 {% endif %}
 {% endblock socials %}
 


### PR DESCRIPTION
If a member does not have any social links to display, there is no reason to display a ghost title.
This PR removes the hanging title.

Before:

![Screenshot from 2022-01-13 21-12-05](https://user-images.githubusercontent.com/6994982/149387669-2c57f96a-1bdb-489c-a59d-a749126cbd42.png)

After: 

![Screenshot from 2022-01-13 21-12-19](https://user-images.githubusercontent.com/6994982/149387659-5731ed01-b3d1-49ae-a22e-10d3a79caee1.png)


