### PR TITLE
PMG-107: fix messages page

### DIFF
--- a/pombola/south_africa/static/js/person-messages-ajax.js
+++ b/pombola/south_africa/static/js/person-messages-ajax.js
@@ -8,7 +8,9 @@ $(function () {
     $.ajax({
       url: url
     }).done(function (html) {
-      $panel.html($(html).find(messagesSelector));
+      var content = $(html).find(messagesSelector);
+      content[0].style.display = 'block';
+      $panel.html(content);
     }).fail(function () {
       $panel.html('<p>Error: Unable to load messages at this time. Please try again later.</p>');
     });

--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -4108,6 +4108,7 @@ p.message-title a:hover {
     padding-top: 0.4em;
     color: rgba(0, 0, 0, 0.5);
     font-size: 0.8em;
+    margin-bottom: 0em;
 }
 .read-more {
     color: #e23d29;
@@ -4548,6 +4549,7 @@ p.item-text {
     letter-spacing: 0.01em;
     font-size: 0.95em;
     color: #000;
+    margin-bottom: 0em;
 }
 .mp-col {
     padding-bottom: 1em;

--- a/pombola/writeinpublic/templates/writeinpublic/messages.html
+++ b/pombola/writeinpublic/templates/writeinpublic/messages.html
@@ -2,10 +2,30 @@
 
 {% block title %}WriteInPublic messages to {{ person.name }}{% endblock %}
 
-{% block content %}
-  <div class="js-person-messages-all">
-    <div class="row">
+  {% block content %}
+  <div>
     {% for message in messages %}
+      <div>
+          <h3>
+              <a href="{% url 'writeinpublic:writeinpublic-message' message_id=message.id %}">{{ message.subject }}</a>
+              &ndash; <small>{{ message.created_at|date:"d M Y" }}</small>
+          </h3>
+          <p>
+              {{ message.content|truncatewords:30 }}
+              <a href="{% url 'writeinpublic:writeinpublic-message' message_id=message.id %}">(Read more)</a>
+          </p>
+      </div>
+    {% empty %}
+      {% comment %}
+        TODO: Just hide this panel completely if there are no messages?
+      {% endcomment %}
+      <p>Nothing here!</p>
+    {% endfor %}
+  </div>
+  <!-- Component below is displayed on member profile page only -->
+  <div class="js-person-messages-all" style="display: none;">
+    <div class="row">
+    {% for message in messages|slice:":4" %}
     <div class="col-lg-6 col-md-6 col-sm-12" style="padding-left: 0em; padding-right: 0em;">
       <div class="mp-item is--full" style="padding-left: 1em;">
         <div class="mp-message w-inline-block">
@@ -54,5 +74,5 @@
       </p>
     </a>
   </div>
-</div>
-{% endblock %}
+  </div>
+  {% endblock content %}


### PR DESCRIPTION
Member profile page shall now display the first 4 messages and the all messages page will retain the styling of the pages.

**Before:**

![Screenshot from 2022-01-20 10-56-23](https://user-images.githubusercontent.com/6994982/150296954-77f543fa-e664-418c-98b6-3626e7a2f583.png)


**After:**

![Screenshot from 2022-01-20 10-57-33](https://user-images.githubusercontent.com/6994982/150297004-272f0bc1-c404-4f63-8d47-6d5e628c3eae.png)

![Screenshot from 2022-01-20 10-57-12](https://user-images.githubusercontent.com/6994982/150297012-29f9459a-59a7-4334-a064-969b7662a915.png)

