### PR TITLE
Remove let usage and remove variable declaration in for loop

### DIFF
--- a/pombola/core/static/js/functions.js
+++ b/pombola/core/static/js/functions.js
@@ -230,9 +230,8 @@ $(function () {
   const nameAndEmailIds = ["id_draft-author_name", "id_draft-author_email"]
   const nameAndEmailPlaceholders = ["eg. Jane Smith", "eg. jane@email.com"]
 
-  for (let i = 0; i < nameAndEmailIds.length; i++) {
-    const input = $("#" + nameAndEmailIds[i])
-    if (input) {
+  for (var i = 0; i < nameAndEmailIds.length; i++) {
+    if ($("#" + nameAndEmailIds[i])) {
       input.attr("placeholder", nameAndEmailPlaceholders[i])
       input.attr("required", "")
       input.attr("maxlength", "256")


### PR DESCRIPTION
Functions.js was causing the build to fail and also broke production.

This was caused by using `let` to declare a variable and having a variable inside a for loop.