### PR TITLE
Ensure text not beneath icons

### DIFF
--- a/pombola/south_africa/static/sass/_south-africa_overrides.scss
+++ b/pombola/south_africa/static/sass/_south-africa_overrides.scss
@@ -1173,6 +1173,9 @@ $logo-width-large: 184px;
                     line-height: 1.4;
                     letter-spacing: 0.01em;
                     width: 95%;
+                    @media screen and (max-width: 479px) {
+                        max-width: 80%;
+                    }
                 }
                 &:hover {
                     background-color: hsla(0, 0%, 100%, 0.05);


### PR DESCRIPTION
Use 80% width

**Before**

![Screenshot from 2022-02-08 23-39-15](https://user-images.githubusercontent.com/6994982/153071801-3f596ae0-9981-47bc-9c94-50d15ad8eaf1.png)

**After**

![Screenshot from 2022-02-08 23-38-47](https://user-images.githubusercontent.com/6994982/153071806-de8d04fe-50c3-46e4-87fe-9b7c9c03ab7b.png)
