### PR TITLE
Removed unique_together scheme and identifier

### DIFF
--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -215,9 +215,6 @@ class Identifier(ModelBase):
     def __unicode__(self):
         return '"%s%s"' % (self.scheme, self.identifier)
 
-    class Meta:
-        unique_together = ('scheme', 'identifier')
-
 
 class IdentifierMixin(object):
 


### PR DESCRIPTION
This is to allow saving persons who have the same scheme and identifier in 2024 elections as the IEC is supplying redacted ID numbers.