### PR TITLE
always show activity

### DIFF
--- a/pombola/south_africa/templates/core/person_detail.html
+++ b/pombola/south_africa/templates/core/person_detail.html
@@ -415,7 +415,7 @@
   </div>
   <div style="padding-top: 3em;">
     {% block plenary_appearances %}
-    {% if hansard.count or question.count or committee.count %}
+    
     <h2 class="mp-subheading">Politician Activity</h2>
     <div>
       {% if attendance %}
@@ -639,7 +639,7 @@
         </div>
       </section>
     </div>
-    {% endif %}
+    
     {% endblock %}
   <div>
     {% if object.interests_register_entries.exists %}


### PR DESCRIPTION
This fix removes the hansard, question and committee count check. This should show attendance for all new parties and members. The question is why `committee.count` would not come through. Can we try this and see?