### PR TITLE
Spike Python 3 update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,24 @@ ENV COUNTRY_APP=south_africa
 
 RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list && \
     apt-get update && \
-    apt-get install -y \
-        ruby2.7-dev \
-        antiword \
-        binutils \
-        libffi-dev \
-        libjpeg-dev \
-        libpq-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        libproj-dev \
-        gdal-bin \
-        libgdal-dev \
-        poppler-utils \
-        yui-compressor \
-        zlib1g-dev \
-        postgresql-client \
-        awscli \
-        wget \
-        gnupg2 && \
+    apt-get install -y antiword \
+            binutils \
+            libffi-dev \
+            libjpeg-dev \
+            libpq-dev \
+            libxml2-dev \
+            libxslt1-dev \
+            libproj-dev \
+            gdal-bin \
+            libgdal-dev \
+            poppler-utils \
+            ruby2.7 \
+            ruby2.7-dev \
+            yui-compressor \
+            zlib1g-dev \
+            postgresql-client \
+            awscli \
+            wget && \
     ln -sf /usr/bin/ruby2.7 /usr/bin/ruby && \
     ln -sf /usr/bin/gem2.7 /usr/bin/gem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,31 @@ FROM python:3.9.22-bookworm
 ENV PYTHONUNBUFFERED 1
 ENV COUNTRY_APP=south_africa
 
-RUN apt-get update && \
-    apt-get install -y antiword \
-                       binutils \
-                       libffi-dev \
-                       libjpeg-dev \
-                       libpq-dev \
-                       libxml2-dev \
-                       libxslt1-dev \
-                       libproj-dev \
-                       gdal-bin \
-                       libgdal-dev \
-                       poppler-utils \
-                       ruby-bundler \
-                       ruby-dev \
-                       yui-compressor \
-                       zlib1g-dev \
-                       postgresql-client \
-                       awscli
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list && \
+    apt-get update && \
+    apt-get install -y \
+        ruby2.7-dev \
+        antiword \
+        binutils \
+        libffi-dev \
+        libjpeg-dev \
+        libpq-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libproj-dev \
+        gdal-bin \
+        libgdal-dev \
+        poppler-utils \
+        yui-compressor \
+        zlib1g-dev \
+        postgresql-client \
+        awscli \
+        wget \
+        gnupg2 && \
+    ln -sf /usr/bin/ruby2.7 /usr/bin/ruby && \
+    ln -sf /usr/bin/gem2.7 /usr/bin/gem
+
+RUN gem install bundler
 
 RUN mkdir /app
 RUN mkdir -p /var/celerybeat
@@ -29,8 +36,6 @@ COPY requirements.txt /app/
 RUN pip install -r /app/requirements.txt
 
 COPY . /app/
-# Set WORKDIR after installing, so that src dir isn't created then overwritten
-# by development mount
 WORKDIR /app
 
 RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM python:2-stretch
+FROM python:3.9.22-bookworm
 
 ENV PYTHONUNBUFFERED 1
 ENV COUNTRY_APP=south_africa
-
-RUN echo "deb http://archive.debian.org/debian/ stretch main" > /etc/apt/sources.list \
-    && echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list \
-    && apt-get -o Acquire::Check-Valid-Until=false update
 
 RUN apt-get update && \
     apt-get install -y antiword \
@@ -17,11 +13,10 @@ RUN apt-get update && \
                        libxslt1-dev \
                        libproj-dev \
                        gdal-bin \
+                       libgdal-dev \
                        poppler-utils \
-                       python-dev \
-                       python-gdal \
                        ruby-bundler \
-                       ruby2.3-dev \
+                       ruby-dev \
                        yui-compressor \
                        zlib1g-dev \
                        postgresql-client \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     volumes:
       - ./data:/app-data
       - .:/app
-    command: bin/wait-for-deps.sh celery -A Pombola worker
+    command: bin/wait-for-deps.sh celery -A pombola worker
     depends_on:
       - db
       - elasticsearch

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -23,9 +23,11 @@ this can be modified using the `DATA_DIR` configuration variable.
 ## Development
 
 The code is available via github: https://github.com/OpenUpSA/pombola
+Clone and build:
 
 ```
-git clone https://github.com/OpenUpSA/pombola.git
+git clone https://github.com/OpenUpSA/pombola.git && cd pombola
+docker compose build
 ```
 
 Run migrations

--- a/manage.py
+++ b/manage.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     if run_default_tests(sys.argv):
         settings_module = 'pombola.settings.tests'
-        print "Warning: we recommend running tests with ./run-tests instead"
+        print("Warning: we recommend running tests with ./run-tests instead")
     else:
         settings_module = "pombola.settings.south_africa"
 

--- a/pombola/core/context_processors.py
+++ b/pombola/core/context_processors.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 from django.conf import settings
 from django.contrib.sites.models import Site
 
@@ -31,3 +33,24 @@ def add_settings( request ):
 
 def site_processor(request):
     return {'site': Site.objects.get_current()}
+
+
+def deployment_info(request):
+    hostname = os.environ.get('HOSTNAME', 'unknown')
+
+    git_commit = 'unknown'
+    try:
+        git_commit = subprocess.check_output(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            stderr=subprocess.DEVNULL,
+            timeout=1
+        ).decode('utf-8').strip()
+    except:
+        pass
+
+    return {
+        'deployment': {
+            'hostname': hostname,
+            'git_commit': git_commit,
+        }
+    }

--- a/pombola/core/context_processors.py
+++ b/pombola/core/context_processors.py
@@ -36,21 +36,12 @@ def site_processor(request):
 
 
 def deployment_info(request):
-    hostname = os.environ.get('HOSTNAME', 'unknown')
-
-    git_commit = 'unknown'
-    try:
-        git_commit = subprocess.check_output(
-            ['git', 'rev-parse', '--short', 'HEAD'],
-            stderr=subprocess.DEVNULL,
-            timeout=1
-        ).decode('utf-8').strip()
-    except:
-        pass
+    server_name = os.environ.get('SERVER_NAME', 'unknown')
+    git_commit = os.environ.get('GIT_REV', 'unknown')
 
     return {
         'deployment': {
-            'hostname': hostname,
+            'server_name': server_name,
             'git_commit': git_commit,
         }
     }

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -268,6 +268,9 @@ class ContactKind(ModelBase):
     def __unicode__(self):
         return self.name
 
+    def __str__(self):
+        return self.name
+
     class Meta:
        ordering = ["slug"]
 
@@ -842,6 +845,9 @@ class OrganisationKind(ModelBase):
     def __unicode__(self):
         return self.name
 
+    def __str__(self):
+        return self.name
+
     class Meta:
        ordering = ["slug"]
 
@@ -1037,6 +1043,9 @@ class PlaceKind(ModelBase):
     objects = ManagerBase()
 
     def __unicode__(self):
+        return self.name
+
+    def __str__(self):
         return self.name
 
     class Meta:
@@ -1848,6 +1857,9 @@ class ParliamentarySession(ModelBase):
 
     def __unicode__(self):
         return unicode(self.name)
+
+    def __str__(self):
+        return self.name
 
     def covers_date(self, d):
         return (d >= self.start_date) and (d <= self.end_date)

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -451,7 +451,7 @@ class PersonManager(ManagerBase):
             try:
                 person_id = int(identifier)
             except ValueError:
-                raise self.model.DoesNotExist, "Person matching query does not exist."
+                raise self.model.DoesNotExist("Person matching query does not exist.")
             return self.get(pk=person_id)
 
     def get_featured(self):
@@ -1946,7 +1946,7 @@ def raw_query_with_prefetch(query_model, query, params, fields_prefetches):
     }
     for f in fields:
         if f not in name_to_field:
-            raise Exception, "{0} was not a ForeignKey field".format(f)
+            raise Exception("{0} was not a ForeignKey field".format(f))
     # Find all IDs for each field:
     field_ids = defaultdict(set)
     for o in objects:

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -952,6 +952,9 @@ class Organisation(ModelBase, HasImageMixin, IdentifierMixin):
     def __unicode__(self):
         return "%s (%s)" % (self.name, self.kind)
 
+    def __str__(self):
+        return "%s (%s)" % (self.name, self.kind)
+
     @models.permalink
     def get_absolute_url(self):
         return ('organisation', [self.slug])
@@ -1110,6 +1113,12 @@ class Place(ModelBase, HasImageMixin, ScorecardMixin, BudgetsMixin, IdentifierMi
         return self.kind.name
 
     def __unicode__(self):
+        session_suffix = ""
+        if self.parliamentary_session:
+            session_suffix += " " + str(self.parliamentary_session.short_date_range())
+        return "%s (%s%s)" % (self.name, self.kind, session_suffix)
+
+    def __str__(self):
         session_suffix = ""
         if self.parliamentary_session:
             session_suffix += " " + str(self.parliamentary_session.short_date_range())
@@ -1390,6 +1399,9 @@ class PositionTitle(ModelBase):
     objects = ManagerBase()
 
     def __unicode__(self):
+        return self.name
+
+    def __str__(self):
         return self.name
 
     @models.permalink
@@ -1792,6 +1804,16 @@ class Position(ModelBase, IdentifierMixin):
         super(Position, self).save(*args, **kwargs)
 
     def __unicode__(self):
+        title = self.title or '???'
+
+        if self.organisation:
+            organisation = self.organisation.name
+        else:
+            organisation = '???'
+
+        return "%s (%s at %s)" % ( self.person.legal_name, title, organisation)
+
+    def __str__(self):
         title = self.title or '???'
 
         if self.organisation:

--- a/pombola/core/models.py
+++ b/pombola/core/models.py
@@ -2,7 +2,7 @@ from __future__ import division
 
 import calendar
 import datetime
-from functools import partial
+from functools import partial, reduce
 import re
 import itertools
 import random

--- a/pombola/core/templatetags/breadcrumbs.py
+++ b/pombola/core/templatetags/breadcrumbs.py
@@ -21,7 +21,7 @@ from django.utils.safestring import mark_safe
 from django.core.urlresolvers import resolve, Resolver404
 from django.conf import settings
 import re
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 register = Library()
 

--- a/pombola/core/templatetags/breadcrumbs.py
+++ b/pombola/core/templatetags/breadcrumbs.py
@@ -132,7 +132,7 @@ def escape_link_text_for_html(s):
     >>> escape_link_text_for_html(u'a unicode snowman \u2603 and a hot beverage \u2615')
     'a unicode snowman &#9731; and a hot beverage &#9749;'
     """
-    return escape(s).encode('ascii', 'xmlcharrefreplace')
+    return escape(s).encode('ascii', 'xmlcharrefreplace').decode('ascii')
 
 @register.filter
 def breadcrumbs(url):

--- a/pombola/core/views.py
+++ b/pombola/core/views.py
@@ -15,7 +15,7 @@ import string
 import sys
 import subprocess
 import unicodecsv as csv
-from urlparse import urlsplit, urlunsplit, urljoin
+from urllib.parse import urlsplit, urlunsplit, urljoin
 from os.path import dirname
 
 import django
@@ -769,7 +769,7 @@ class VersionView(View):
                 cwd=dirname(__file__),
             ).strip()
             result['git_version'] = git_version
-        except OSError, subprocess.CalledProcessError:
+        except (OSError, subprocess.CalledProcessError):
             pass
         return HttpResponse(
             json.dumps(result), content_type='application/json'

--- a/pombola/experiments/admin.py
+++ b/pombola/experiments/admin.py
@@ -2,7 +2,7 @@ import csv
 from collections import defaultdict
 import json
 import re
-from StringIO import StringIO
+from io import StringIO
 
 from django.contrib import admin, messages
 from django.forms import ModelForm, ValidationError
@@ -100,9 +100,9 @@ class EventAdminForm(ModelForm):
         if extra_data.strip():
             try:
                 json.loads(extra_data)
-            except ValueError, ve:
+            except ValueError as ve:
                 message = "The extra data must be empty or valid JSON: {0}"
-                raise ValidationError, message.format(ve)
+                raise ValidationError(message.format(ve))
         return extra_data
 
 

--- a/pombola/feedback/views.py
+++ b/pombola/feedback/views.py
@@ -5,8 +5,8 @@ from django.views.decorators.csrf import csrf_protect
 
 from pombola.core.recaptcha import recaptcha_client
 
-from models import Feedback
-from forms import FeedbackForm
+from .models import Feedback
+from .forms import FeedbackForm
 
 import re
 

--- a/pombola/pipeline/compressor.py
+++ b/pombola/pipeline/compressor.py
@@ -5,7 +5,7 @@ class LoggingYUICompressor(YUICompressor):
   def compress_js(self, js):
       try:
           return super(LoggingYUICompressor, self).compress_js(js)
-      except Exception, e:
+      except Exception as e:
           print("Error in the following content (this might be a bundle and not a source file):\n")
           print(js)
           raise e
@@ -13,7 +13,7 @@ class LoggingYUICompressor(YUICompressor):
   def compress_css(self, css):
       try:
           return super(LoggingYUICompressor, self).compress_css(css)
-      except Exception, e:
+      except Exception as e:
           print("Error in the following content (this might be a bundle and not a source file):\n")
           print(css)
           raise e

--- a/pombola/search/views.py
+++ b/pombola/search/views.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import re
 import sys
-import simplejson
+import json
 import logging
 
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -508,6 +508,6 @@ def autocomplete(request):
 
     # send back the results as JSON
     return HttpResponse(
-        simplejson.dumps(response_data),
+        json.dumps(response_data),
         content_type='application/json',
     )

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -14,7 +14,6 @@ from corsheaders.defaults import default_headers
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.celery import CeleryIntegration
-import djcelery
 
 from urllib.parse import urlparse
 
@@ -446,6 +445,7 @@ INSTALLED_APPS = (
     "info",
     "pombola.tasks",
     "pombola.core",
+    "pombola.core.images",
     "pombola.feedback",
     "pombola.scorecards",
     "pombola.search",
@@ -457,7 +457,6 @@ INSTALLED_APPS = (
     "django_nose",
     "django_extensions",
     "rest_framework",
-    "djcelery",
 )
 
 if os.environ.get("DJANGO_DEBUG_TOOLBAR", "true").lower() == "true":
@@ -721,4 +720,3 @@ CELERY_RESULT_BACKEND = os.environ.get("CELERY_BROKER_URL")
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TASK_SERIALIZER = 'json'
-djcelery.setup_loader()

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -143,7 +143,7 @@ MEDIA_ROOT = os.path.normpath(os.path.join(data_dir, "media_root/"))
 FILE_UPLOAD_PERMISSIONS = 0o644  # 'rw-r--r--'
 
 # Use django-pipeline for handling static files
-STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
+STATICFILES_STORAGE = "pipeline.storage.PipelineManifestStorage"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -218,6 +218,7 @@ if os.environ.get("DJANGO_DEBUG_TOOLBAR", "false").lower() == "true":
 
 MIDDLEWARE_CLASSES += (
     "corsheaders.middleware.CorsMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.cache.UpdateCacheMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -66,6 +66,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "pombola.core.context_processors.add_settings",
                 "pombola.core.context_processors.site_processor",
+                "pombola.core.context_processors.deployment_info",
                 "constance.context_processors.config",
             ],
             "debug": DEBUG,

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -143,7 +143,7 @@ MEDIA_ROOT = os.path.normpath(os.path.join(data_dir, "media_root/"))
 FILE_UPLOAD_PERMISSIONS = 0o644  # 'rw-r--r--'
 
 # Use django-pipeline for handling static files
-STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -218,6 +218,7 @@ if os.environ.get("DJANGO_DEBUG_TOOLBAR", "false").lower() == "true":
 
 MIDDLEWARE_CLASSES += (
     "corsheaders.middleware.CorsMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.cache.UpdateCacheMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -143,7 +143,7 @@ MEDIA_ROOT = os.path.normpath(os.path.join(data_dir, "media_root/"))
 FILE_UPLOAD_PERMISSIONS = 0o644  # 'rw-r--r--'
 
 # Use django-pipeline for handling static files
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -506,8 +506,8 @@ def make_enabled_features(installed_apps, all_optional_apps):
 
 PIPELINE = {
     "COMPILERS": ("pipeline_compass.compass.CompassCompiler",),
-    "CSS_COMPRESSOR": "pombola.pipeline.compressor.LoggingYUICompressor",
-    "JS_COMPRESSOR": "pombola.pipeline.compressor.LoggingYUICompressor",
+    "CSS_COMPRESSOR": None, # "pombola.pipeline.compressor.LoggingYUICompressor",
+    "JS_COMPRESSOR": None, # "pombola.pipeline.compressor.LoggingYUICompressor",
     "YUI_BINARY": "/usr/bin/env yui-compressor",
     "DISABLE_WRAPPER": True,
 }

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -16,7 +16,7 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.celery import CeleryIntegration
 import djcelery
 
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 IN_TEST_MODE = False
 

--- a/pombola/settings/base.py
+++ b/pombola/settings/base.py
@@ -143,7 +143,7 @@ MEDIA_ROOT = os.path.normpath(os.path.join(data_dir, "media_root/"))
 FILE_UPLOAD_PERMISSIONS = 0o644  # 'rw-r--r--'
 
 # Use django-pipeline for handling static files
-STATICFILES_STORAGE = "pipeline.storage.PipelineManifestStorage"
+STATICFILES_STORAGE = "pipeline.storage.PipelineCachedStorage"
 
 # Absolute path to the directory static files should be collected to.
 # Don't put anything in this directory yourself; store your static files
@@ -218,7 +218,6 @@ if os.environ.get("DJANGO_DEBUG_TOOLBAR", "false").lower() == "true":
 
 MIDDLEWARE_CLASSES += (
     "corsheaders.middleware.CorsMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.cache.UpdateCacheMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/pombola/south_africa/templates/core/generic_list_item.html
+++ b/pombola/south_africa/templates/core/generic_list_item.html
@@ -1,24 +1,21 @@
-{% load switch %}
-
 {% if object.kind.slug == 'parliament' %}
     <li class="parliament-list-item">
         {% include "core/parliament_list_item.html" %}
     </li>
 {% else %}
     <li class="list-of-things-item {{ object.css_class }}-list-item{% if not object.show_active %} inactive{% endif %}">
-        {% switch object.css_class %}
-            {% case 'position' %}
-                {% include "core/position_list_item.html" %}
-            {% case 'positiontitle' %}
-                {% include "core/positiontitle_list_item.html" %}
-            {% case 'person' %}
-                {% include "core/person_list_item.html" %}
-            {% case 'organisation' %}
-                {% include "core/organisation_list_item.html" %}
-            {% case 'place' %}
-                {% include "core/place_list_item.html" %}
-            {% else %}
-                {% include "core/unknown_list_item.html" %}
-        {% endswitch %}
+        {% if object.css_class == 'position' %}
+            {% include "core/position_list_item.html" %}
+        {% elif object.css_class == 'positiontitle' %}
+            {% include "core/positiontitle_list_item.html" %}
+        {% elif object.css_class == 'person' %}
+            {% include "core/person_list_item.html" %}
+        {% elif object.css_class == 'organisation' %}
+            {% include "core/organisation_list_item.html" %}
+        {% elif object.css_class == 'place' %}
+            {% include "core/place_list_item.html" %}
+        {% else %}
+            {% include "core/unknown_list_item.html" %}
+        {% endif %}
     </li>
 {% endif %}

--- a/pombola/south_africa/templates/core/person_detail_position.html
+++ b/pombola/south_africa/templates/core/person_detail_position.html
@@ -2,36 +2,36 @@
 
 {% with org=position.organisation %}
   <p class="text-link__text">
-    {{ position.title }}
+    {{ position.title.name }}
     {% if org %}
       {% if 'election-list' in org.slug %}
         {% with year=position.start_date.year|stringformat:"s" province=org.slug|get_place_slug %}
           {% if 'provincial' in org.slug %}
             at
             <a href="{% url "sa-election-candidates-provincial-party" election_year=year party_name=org.slug|get_party_slug province_name=province %}">
-              {{org}}
+              {{ org.name }}
             </a>
           {% elif 'national' in org.slug %}
             at
             <a href="{% url "sa-election-candidates-national-party" election_year=year party_name=org.slug|get_party_slug %}">
-              {{org}}
+              {{ org.name }}
             </a>
           {% elif province %}
             at
             <a href="{% url "sa-election-candidates-national-province-party" election_year=year party_name=org.slug|get_party_slug province_name=province %}">
-              {{org}}
+              {{ org.name }}
             </a>
           {% else %}
             at
             <a href="{% url "organisation" slug=org.slug %}">
-              {{ org }}
+              {{ org.name }}
             </a>
           {% endif %}
         {% endwith %}
       {% else %}
         at
         <a href="{% url "organisation" slug=org.slug %}">
-          {{ org }}
+          {{ org.name }}
         </a>
       {% endif %}
     {% endif %}

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -302,18 +302,18 @@ class SAMpAttendanceView(TemplateView):
                     aggregate_total = aggregate_present = 0
 
                     for summary in attendance_summary:
-                        total = sum(v for v in summary['attendance'].itervalues())
+                        total = sum(v for v in summary['attendance'].values())
 
                         present = sum(
-                            v for k, v in summary['attendance'].iteritems()
+                            v for k, v in summary['attendance'].items()
                             if k in present_codes)
 
                         arrive_late = sum(
-                            v for k, v in summary['attendance'].iteritems()
+                            v for k, v in summary['attendance'].items()
                             if k in arrive_late_codes)
 
                         depart_early = sum(
-                            v for k, v in summary['attendance'].iteritems()
+                            v for k, v in summary['attendance'].items()
                             if k in depart_early_codes)
 
                         aggregate_total += total
@@ -344,7 +344,7 @@ class SAMpAttendanceView(TemplateView):
                     # No aggregates are calculated
                     for summary in attendance_summary:
                         present = sum(
-                            v for k, v in summary['attendance'].iteritems()
+                            v for k, v in summary['attendance'].items()
                             if k in present_codes)
                         context['attendance_data'].append({
                                 "name": summary['member']['name'],

--- a/pombola/south_africa/views/attendance.py
+++ b/pombola/south_africa/views/attendance.py
@@ -4,7 +4,7 @@ import dateutil
 import json
 import requests
 import datetime
-from urlparse import urlsplit
+from urllib.parse import urlsplit
 from collections import defaultdict
 
 from .constants import API_REQUESTS_TIMEOUT
@@ -14,7 +14,7 @@ from django.views.generic import TemplateView
 from django.shortcuts import get_object_or_404
 
 from pombola.core.models import Position, Person
-from person import SAPersonDetail
+from .person import SAPersonDetail
 
 
 class SAMpAttendanceView(TemplateView):

--- a/pombola/south_africa/views/person.py
+++ b/pombola/south_africa/views/person.py
@@ -10,7 +10,7 @@ import datetime
 import pytz
 
 from .constants import API_REQUESTS_TIMEOUT
-from urlparse import urlsplit
+from urllib.parse import urlsplit
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches

--- a/pombola/tasks/admin.py
+++ b/pombola/tasks/admin.py
@@ -10,7 +10,7 @@ from django.template   import RequestContext
 
 from slug_helpers.admin import StricterSlugFieldMixin
 
-import models
+from . import models
 
 
 def create_admin_url_for(obj):

--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -139,7 +139,7 @@
 
               {% if deployment %}
               <p style="font-size: 0.8em; color: #999; margin-top: 10px;">
-                {{ deployment.hostname }} | {{ deployment.git_commit }}
+                {{ deployment.server_name }} | {{ deployment.git_commit }}
               </p>
               {% endif %}
 

--- a/pombola/templates/default_base.html
+++ b/pombola/templates/default_base.html
@@ -137,6 +137,12 @@
               {% block extra_attribution %}
               {% endblock %}
 
+              {% if deployment %}
+              <p style="font-size: 0.8em; color: #999; margin-top: 10px;">
+                {{ deployment.hostname }} | {{ deployment.git_commit }}
+              </p>
+              {% endif %}
+
             </div>
         </footer>
         {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ django-pipeline-compass-rubygem==0.1.9
 django-formtools==2.1
 django-cors-headers==1.3.1
 django-storages==1.9.1
-whitenoise==5.3.0
 
 
 ### API related

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ django-pipeline-compass-rubygem==0.1.9
 django-formtools==2.1
 django-cors-headers==1.3.1
 django-storages==1.9.1
+whitenoise==5.3.0
 
 
 ### API related

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@
 # more details: http://www.pip-installer.org/en/latest/requirements.html
 
 gunicorn==19.9.0
-gevent==1.4.0
-greenlet==0.4.15
+gevent==20.12.1
+greenlet==0.4.17
 psycogreen==1.0.1
 
 ### General useful bits
@@ -19,7 +19,7 @@ dj-database-url==0.5.0
 ### Django related
 Django==1.11.29
 ## django-pagination
--e git+https://github.com/OpenUpSA/django-pagination@d013c9c1facf7e1d6827a5a7929064c5c80c53e2#egg=django-pagination
+-e git+https://github.com/OpenUpSA/django-pagination@d013c9c1facf7e1d6827a5a7929064c5c80c53e2#egg=mysociety-django-pagination
 django-bcrypt==0.9.2
 django-pipeline==1.6.13
 django-pipeline-compass-rubygem==0.1.9
@@ -43,11 +43,11 @@ django-date-extensions==3.0
 django-ajax-selects==1.9.1
 django-autocomplete-light==2.3.3
 django-slug-helpers==0.0.3
-django-file-archive==0.0.2
+-e git+https://github.com/michaelglenister/django-file-archive@e394d4b7ef8bcbb607e62ec306ae215770b6d118#egg=django-file-archive
 # django-info-pages
--e git+https://github.com/OpenUpSA/django-info-pages@a592d2f00f205051c50ee4f5a4e19e4ad4c25c6a#egg=django-info-pages
+-e git+https://github.com/michaelglenister/django-info-pages@77b39a437c79da227276f5211e846850c34c9881#egg=django-info-pages
 
-Markdown==2.5.1
+Markdown==2.6.11
 
 lxml==4.9.1
 
@@ -63,7 +63,7 @@ requests==2.27.1
 elasticsearch==1.9.0
 django-haystack==2.8.1
 # Required (but not a declared requirement) of elasticsearch
-urllib3==1.26.19
+urllib3==1.26.20
 
 # Testing helpers
 django-nose==1.4.5
@@ -80,10 +80,9 @@ selenium==2.53.6
 django-selenium==0.9.7
 
 # Hansard parsing is quite particular
-BeautifulSoup==3.2.1
-beautifulsoup4==4.3.2
+beautifulsoup4==4.13.4
 Unidecode==0.4.16
-python-memcached==1.53
+python-memcached==1.62
 
 # django-mapit
 django-mapit==1.6
@@ -93,7 +92,7 @@ django-mapit==1.6
 -e git+https://github.com/OpenUpSA/sayit.git@7b4ec402239d8dd1118f9d078858b9bced868f57#egg=django-sayit
 
 mysociety-django-sluggable==0.6.1.1
--e git+https://github.com/mysociety/popolo-name-resolver@a6fca27e080acdb475e6fd2e1382592b0c0a0fc5#egg=popolo-name-resolver
+-e git+https://github.com/michaelglenister/popolo-name-resolver@b15266f42cbb0660d649b48adf3c5f356ea27152#egg=popolo-name-resolver
 
 mysociety-django-popolo==0.1.0
 
@@ -117,40 +116,23 @@ pygeocoder==1.2.5
 # Dependencies of our dependencies
 # Django-Select2==4.3.2
 # mysociety-Django-Select2==4.3.2.2
--e git+https://github.com/mysociety/django-select2@28c9bf981017d83836390b264a0fa8dd246e6a07#egg=Django-Select2
+-e git+https://github.com/mysociety/django-select2@28c9bf981017d83836390b264a0fa8dd246e6a07#egg=mysociety-Django-Select2
 Shapely==1.5.0
 WebOb==1.4
-amqp==1.4.6
-anyjson==0.3.3
+-e git+https://github.com/michaelglenister/anyjson@732424b8cfb72d98bcb46950cb4102b508829bc4#egg=anyjson
 audioread==1.0.3
-billiard==3.3.0.19
 bleach==3.3.0
 django-appconf==1.0.2
 celery==3.1.25
 celery-haystack==0.10
 kombu==3.0.37
-chardet==2.3.0
+chardet==3.0.4
 cssselect==0.9.1
 django-bleach==0.5.2
-django-celery==3.1.17
+django-celery==3.3.1
 django-qmethod==0.0.3
 django-subdomain-instances==3.0.2
 django-tastypie==0.12.1
-html5lib==0.999
-mechanize==0.4.6
-mimeparse==0.1.3
-mock==1.3.0
-nose==1.3.4
-parslepy==0.2.0
-python-magic==0.4.6
-pytz==2014.10
-simplejson==3.6.5
-six==1.10.0
-slumber==0.6.2
-sqlparse==0.2.0
-virtualenv==1.11.6
-wsgi-intercept==0.8.0
-wsgiref==0.1.2
 
 # We cannot pin these to specific versions, because they're OS/Python version
 # dependant, and there's no single version which will work for the variety of
@@ -160,9 +142,6 @@ wsgiref==0.1.2
 # Pinned to 1.1 rather than 1.2.1 to save us having to use --allow-all-external
 argparse==1.1
 
-# Used for keeping an eye on this file.
-pip-tools==0.3.5
-
 # Other things presumably installed as dependencies of stuff above
 python-mimeparse==0.1.4
 approx-dates==0.0.1
@@ -171,7 +150,7 @@ easy-thumbnails==2.6
 enum34==1.1.10
 funcsigs==1.0.2
 future==0.18.3
-futures==3.3.0
+futures==3.1.1
 idna==2.7
 ipaddress==1.0.23
 libsass==0.20.1
@@ -184,16 +163,15 @@ uk-postcode-utils==1.1
 unicode-slugify==0.1.1
 waitress==1.4.4
 
-
 #necessary to process unicode csv files for ZA elections data
-unicodecsv==0.9.4
+unicodecsv==0.14.1
 
 # Used to format budgetary things into local currency strings
 Babel==2.9.1
 
 # Pin certifi to a version that works with OpenSSL 1.0.1 - see
 # https://github.com/certifi/python-certifi/issues/26
-certifi==2015.04.28
+certifi==2017.4.17
 
 cffi==1.14.4
 
@@ -212,4 +190,4 @@ xlrd==1.2.0
 #sentry-sdk[django]==1.39.2
 sentry-sdk==0.14.3
 
-boto3==1.17.112
+boto3==1.38.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ django-registration-defaults==0.3
 
 ### Pombola dependencies
 sorl-thumbnail==12.4.1
+whitenoise==6.6.0
 django-date-extensions==3.0
 django-ajax-selects==1.9.1
 django-autocomplete-light==2.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,13 +123,12 @@ WebOb==1.4
 audioread==1.0.3
 bleach==3.3.0
 django-appconf==1.0.2
-celery==3.1.25
+celery==4.4.7
 celery-haystack==0.10
-kombu==3.0.37
+kombu==4.6.11
 chardet==3.0.4
 cssselect==0.9.1
 django-bleach==0.5.2
-django-celery==3.3.1
 django-qmethod==0.0.3
 django-subdomain-instances==3.0.2
 django-tastypie==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ django-mapit==1.6
 
 # SayIt and ZA hansard scrapers - need to be made available to be added as an optional app
 # Note, if the subsequent -e are ever removed, please remove manually from virtualenv/src !
--e git+https://github.com/OpenUpSA/sayit.git@7b4ec402239d8dd1118f9d078858b9bced868f57#egg=django-sayit
+-e git+https://github.com/michaelglenister/sayit.git@83877edbc2320d0710a77a1ac466a5d4ce3649fa#egg=django-sayit
 
 mysociety-django-sluggable==0.6.1.1
 -e git+https://github.com/michaelglenister/popolo-name-resolver@b15266f42cbb0660d649b48adf3c5f356ea27152#egg=popolo-name-resolver


### PR DESCRIPTION
The container can build and start the webserver but returns some error to do with Django tags/CSS static hosting

Other efforts to update the environment:
https://github.com/OpenUpSA/pombola/tree/delena-upgrade-python
https://github.com/OpenUpSA/pombola/tree/delena-python-3-upgrade-2

These self-hosted Python packages were moved and fixed, once we are happy with the Py3 update these packages should be moved to the OpenUp account:
https://github.com/michaelglenister/django-file-archive
https://github.com/michaelglenister/django-info-pages
https://github.com/michaelglenister/sayit
https://github.com/michaelglenister/popolo-name-resolver
https://github.com/michaelglenister/anyjson (Previously hosted on PyPI, but no longer maintained)

3rd party, self-hosted packages not updated:
https://github.com/ubernostrum/django-registration
https://github.com/nathforge/django-mechanize
https://github.com/mysociety/django-select2
